### PR TITLE
perf: optimize frontend rendering for mobile devices

### DIFF
--- a/frontend/src/components/browse/ItemCard.tsx
+++ b/frontend/src/components/browse/ItemCard.tsx
@@ -10,6 +10,7 @@ import { formatDate } from '@/lib/date';
 import { SalesTypeEnum, StatusB0aEnum } from '@/services/django';
 import { Badge, Button, Card, Text, Tooltip } from '@mantine/core';
 import { Clock, Globe, Zap } from 'lucide-react';
+import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface ItemCardProps {
@@ -35,7 +36,7 @@ interface ItemCardProps {
   remoteInstance?: string | null;
 }
 
-export const ItemCard = ({
+const ItemCardComponent = ({
   id,
   title,
   description,
@@ -99,7 +100,7 @@ export const ItemCard = ({
     <Card
       withBorder
       padding="lg"
-      className="group overflow-hidden transition-all duration-300 hover:shadow-strong hover:scale-105 animate-fade-in cursor-pointer"
+      className="group overflow-hidden transition-shadow duration-300 hover:shadow-strong animate-fade-in cursor-pointer"
       onClick={() => navigate(`/item/${id}`)}
     >
       {/* Image Section */}
@@ -108,6 +109,8 @@ export const ItemCard = ({
           <img
             src={imageUrl}
             alt={title}
+            loading="lazy"
+            decoding="async"
             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
           />
         ) : (
@@ -168,7 +171,7 @@ export const ItemCard = ({
                   color="blue"
                   size="sm"
                   leftSection={<Globe size={12} />}
-                  className="shadow-medium cursor-default backdrop-blur-xs"
+                  className="shadow-medium cursor-default"
                 >
                   <span className="max-w-24 truncate">{remoteInstance}</span>
                 </Badge>
@@ -180,7 +183,7 @@ export const ItemCard = ({
         {/* Price overlay */}
         {price !== undefined && (
           <div className="absolute bottom-3 right-3">
-            <div className="rounded-lg bg-background/90 backdrop-blur-xs px-3 py-1 shadow-medium">
+            <div className="rounded-lg bg-background/95 px-3 py-1 shadow-medium">
               <div className="flex items-center gap-1 text-sm font-semibold">
                 {formatPrice(price, priceCurrency)}
                 {(salesType === 'rent' || salesType === 'borrow') && (
@@ -296,3 +299,5 @@ export const ItemCard = ({
     </Card>
   );
 };
+
+export const ItemCard = memo(ItemCardComponent);

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -67,7 +67,7 @@ export const Header = () => {
 
   if (!user) {
     return (
-      <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <header className="sticky top-0 z-50 border-b border-border bg-background/95 md:bg-background/80 md:backdrop-blur-md">
         <div className="container mx-auto px-4 py-3">
           <div className="flex items-center justify-between gap-4">
             <NavLink to="/" className="flex items-center gap-3">
@@ -80,7 +80,7 @@ export const Header = () => {
               </div>
             </NavLink>
             <form className="flex-1 max-w-lg" onSubmit={handleSubmit}>
-              <div className={cn('relative transition-all duration-300 focus-within:scale-105')}>
+              <div className="relative">
                 <TextInput
                   placeholder={t('header.search')}
                   leftSection={<Search size={16} aria-hidden="true" />}
@@ -106,7 +106,7 @@ export const Header = () => {
   }
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/95 md:bg-background/80 md:backdrop-blur-md">
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-center justify-between gap-4">
           {/* Logo */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -122,7 +122,7 @@ export const Header = () => {
 
           {/* Search Bar */}
           <form className="flex-1 max-w-lg" onSubmit={handleSubmit}>
-            <div className={cn('relative transition-all duration-300 focus-within:scale-105')}>
+            <div className="relative">
               <TextInput
                 placeholder={t('header.search')}
                 leftSection={<Search size={16} aria-hidden="true" />}

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
 const LANGUAGES = ['en', 'de'] as const;
 export type Language = (typeof LANGUAGES)[number];
@@ -1157,25 +1157,29 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     return 'en';
   });
 
-  const setLanguage = (lang: Language) => {
+  const setLanguage = useCallback((lang: Language) => {
     setLanguageState(lang);
     localStorage.setItem('bubble-language', lang);
-  };
+  }, []);
 
-  const syncLanguage = (lang: Language) => {
+  const syncLanguage = useCallback((lang: Language) => {
     setLanguageState(lang);
     localStorage.setItem('bubble-language', lang);
-  };
+  }, []);
 
-  const t = (key: string): string => {
-    return translations[language][key as keyof (typeof translations)['en']] || key;
-  };
-
-  return (
-    <LanguageContext.Provider value={{ language, setLanguage, syncLanguage, t }}>
-      {children}
-    </LanguageContext.Provider>
+  const t = useCallback(
+    (key: string): string => {
+      return translations[language][key as keyof (typeof translations)['en']] || key;
+    },
+    [language],
   );
+
+  const value = useMemo(
+    () => ({ language, setLanguage, syncLanguage, t }),
+    [language, setLanguage, syncLanguage, t],
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
 };
 
 export const useLanguage = () => {

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import { authAPI, Session, SessionResponse, User } from '@/services/custom/auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react';
 
 interface AuthContextType {
   user?: User;
@@ -68,21 +68,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     },
   });
 
-  const signOut = async () => {
+  const signOut = useCallback(async () => {
     await logoutMutation.mutateAsync();
-  };
+  }, [logoutMutation]);
 
-  const refreshAuth = () => {
+  const refreshAuth = useCallback(() => {
     return queryClient.invalidateQueries({ queryKey: ['session'] });
-  };
+  }, [queryClient]);
 
-  const value = {
-    user: sessionData?.user,
-    session: sessionData ?? null,
-    loading: isLoading,
-    signOut,
-    refreshAuth,
-  };
+  const value = useMemo(
+    () => ({
+      user: sessionData?.user,
+      session: sessionData ?? null,
+      loading: isLoading,
+      signOut,
+      refreshAuth,
+    }),
+    [sessionData, isLoading, signOut, refreshAuth],
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -158,3 +158,16 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Respect users who prefer reduced motion: drop animations and transitions
+   that otherwise cost paint/compositing work on low-power devices. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -30,18 +30,27 @@ if (dsn) {
   // get sentryId from dsn, which is the part after the last '/'
   const sentryId = dsn.split('/').pop();
 
+  // Performance tracing and the auto-injected feedback widget add meaningful
+  // CPU/JS overhead on phones and low-power devices, so trim them there.
+  const isMobile =
+    typeof navigator !== 'undefined' && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
   Sentry.init({
     dsn: dsn,
     // Adds request headers and IP for users, for more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
-    tracesSampleRate: 1.0,
+    tracesSampleRate: isMobile ? 0.1 : 1.0,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.feedbackIntegration({
-        colorScheme: 'system',
-        autoInject: true,
-      }),
+      ...(isMobile
+        ? []
+        : [
+            Sentry.feedbackIntegration({
+              colorScheme: 'system',
+              autoInject: true,
+            }),
+          ]),
     ],
     tunnel: `/sentry-tunnel/${sentryId}/`, // Proxy endpoint to hide the DSN from the client
   });


### PR DESCRIPTION
Targeted mobile/low-power performance pass — the "quick wins" from investigating reported scroll lag. Behavior-preserving; no dependencies added.

## Root causes addressed

1. **Sticky header with `backdrop-blur-md`** (`Header.tsx`) — a blurred sticky bar forces the browser to re-capture and re-blur the whole viewport on every scroll frame, the single biggest scroll-jank source on mobile GPUs. Now gated behind `md:`; mobile gets a more opaque (`/95`) solid background instead.
2. **Per-card blur overlays** (`ItemCard.tsx`) — the price chip and remote-instance badge each used `backdrop-blur-xs`, so a 20-item grid had ~40 blur regions repainting while scrolling. Removed; opacity bumped to compensate.
3. **Images decoding on the main thread** — grid `<img>` had no `loading`/`decoding` hints. Added `loading="lazy"` + `decoding="async"`.
4. **Broad transitions** — `transition-all` on cards (and a `focus-within:scale-105` on the header search) scoped down to `transition-shadow` / removed.
5. **Re-render churn** — `LanguageContext` and `useAuth` rebuilt their provider value object every render, and `ItemCard` wasn't memoized, so any state change re-rendered every card. Provider values + callbacks are now memoized and `ItemCard` is wrapped in `React.memo`.
6. **Sentry overhead** — `tracesSampleRate` was `1.0` and the feedback widget auto-injected. On mobile user agents, sampling drops to `0.1` and the widget is skipped.
7. **Reduced motion** — added a global `prefers-reduced-motion: reduce` rule.

## Verification

- `npm run build` ✅
- `npm run typecheck`: 8 errors, all pre-existing on `main` (generated-API type mismatches) — none introduced.
- `npm run lint`: no new errors/warnings (the `Header.tsx:60` setState-in-effect error and the provider/hook export warnings pre-date this branch).
- `prettier --check` ✅

Items 1–4 give most of the scroll-smoothness win; 5–7 help general responsiveness and load on weak devices.

Not included (deferred per scope): route-level `React.lazy` code-splitting, dynamic-importing the barcode scanner / 1 MB WASM, and list virtualization with `@tanstack/react-virtual`. Happy to do those as a follow-up.

https://claude.ai/code/session_01GFntpWdNMPGEFAiAbojiiR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFntpWdNMPGEFAiAbojiiR)_