### PR TITLE
refactor: improve ItemDetail view and image carousel

### DIFF
--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -217,7 +217,8 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
                   <img
                     src={image.original || imageSrc(image)}
                     alt={`${itemName} — ${index + 1}`}
-                    className="max-h-[90vh] max-w-[92vw] object-contain"
+                    onClick={fullscreen.close}
+                    className="max-h-[90vh] max-w-[92vw] cursor-zoom-out object-contain"
                   />
                 </Carousel.Slide>
               ))}

--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -89,7 +89,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
     <>
       {/* Inline gallery */}
       <div
-        className="group relative overflow-hidden rounded-xl bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mantine-primary-color-filled)]"
+        className="group relative self-start overflow-hidden rounded-xl bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mantine-primary-color-filled)]"
         role="group"
         aria-roledescription="carousel"
         aria-label={itemName}

--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -89,7 +89,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
     <>
       {/* Inline gallery */}
       <div
-        className="group relative self-start overflow-hidden rounded-xl bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mantine-primary-color-filled)]"
+        className="group relative self-start h-64 overflow-hidden rounded-xl bg-[var(--mantine-color-default-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mantine-primary-color-filled)] sm:h-72 md:h-80 lg:h-96"
         role="group"
         aria-roledescription="carousel"
         aria-label={itemName}
@@ -101,6 +101,8 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
           withControls={false}
           getEmblaApi={setInlineApi}
           onSlideChange={setActiveIndex}
+          className="h-full w-full"
+          styles={{ viewport: { height: '100%' }, container: { height: '100%' } }}
         >
           {images.map((image, index) => (
             <Carousel.Slide key={image.id ?? index}>
@@ -108,12 +110,12 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
                 type="button"
                 onClick={() => openFullscreen(index)}
                 aria-label={t('itemDetail.openImage')}
-                className="block h-64 w-full cursor-zoom-in sm:h-72 md:h-80 lg:h-96"
+                className="relative block h-full w-full cursor-zoom-in"
               >
                 <img
                   src={imageSrc(image)}
                   alt={`${itemName} — ${index + 1}`}
-                  className="h-full w-full object-cover"
+                  className="absolute inset-0 h-full w-full object-cover"
                   loading={index === 0 ? 'eager' : 'lazy'}
                 />
               </button>
@@ -123,7 +125,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
 
         {/* Counter badge */}
         {counter && (
-          <div className="pointer-events-none absolute right-3 top-3 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white">
+          <div className="pointer-events-none absolute right-3 top-3 rounded-full bg-black/60 shadow-md px-2.5 py-1 text-xs font-medium text-white">
             {counter}
           </div>
         )}
@@ -136,7 +138,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
           size="lg"
           aria-label={t('itemDetail.openImage')}
           onClick={() => openFullscreen(activeIndex)}
-          className="absolute bottom-3 right-3 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+          className="absolute bottom-3 right-3 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
         >
           <Expand size={18} />
         </ActionIcon>
@@ -151,7 +153,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
               size="lg"
               aria-label={t('itemDetail.previousImage')}
               onClick={() => scrollPrev(inlineApi)}
-              className="absolute left-3 top-1/2 -translate-y-1/2 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="absolute left-3 top-1/2 -translate-y-1/2 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
             >
               <ChevronLeft size={20} />
             </ActionIcon>
@@ -162,7 +164,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
               size="lg"
               aria-label={t('itemDetail.nextImage')}
               onClick={() => scrollNext(inlineApi)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="absolute right-3 top-1/2 -translate-y-1/2 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
             >
               <ChevronRight size={20} />
             </ActionIcon>

--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -6,7 +6,15 @@ import { ActionIcon } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { EmblaCarouselType } from 'embla-carousel';
 import { ChevronLeft, ChevronRight, Expand, X } from 'lucide-react';
-import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useState } from 'react';
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 interface ItemImageCarouselProps {
   images: Image[];
@@ -37,6 +45,24 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
 
   const scrollPrev = useCallback((api: EmblaCarouselType | null) => api?.scrollPrev(), []);
   const scrollNext = useCallback((api: EmblaCarouselType | null) => api?.scrollNext(), []);
+
+  // Track the pointer-down position so we can tell a real click apart from the
+  // click that fires at the end of a drag/swipe (Embla doesn't expose this here).
+  const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
+  const DRAG_THRESHOLD = 10; // px
+
+  const handlePointerDown = (e: ReactPointerEvent) => {
+    pointerDownRef.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const wasTap = (e: ReactMouseEvent) => {
+    const start = pointerDownRef.current;
+    if (!start) return true;
+    return (
+      Math.abs(e.clientX - start.x) < DRAG_THRESHOLD &&
+      Math.abs(e.clientY - start.y) < DRAG_THRESHOLD
+    );
+  };
 
   const openFullscreen = (index: number) => {
     setActiveIndex(index);
@@ -108,7 +134,11 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
             <Carousel.Slide key={image.id ?? index}>
               <button
                 type="button"
-                onClick={() => openFullscreen(index)}
+                onPointerDown={handlePointerDown}
+                onClick={e => {
+                  // Ignore the click that ends a drag/swipe.
+                  if (wasTap(e)) openFullscreen(index);
+                }}
                 aria-label={t('itemDetail.openImage')}
                 className="relative block h-full w-full cursor-zoom-in"
               >
@@ -217,7 +247,11 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
                   <img
                     src={image.original || imageSrc(image)}
                     alt={`${itemName} — ${index + 1}`}
-                    onClick={fullscreen.close}
+                    onPointerDown={handlePointerDown}
+                    onClick={e => {
+                      // Only close on a real click, not at the end of a drag/swipe.
+                      if (wasTap(e)) fullscreen.close();
+                    }}
                     className="max-h-[90vh] max-w-[92vw] cursor-zoom-out object-contain"
                   />
                 </Carousel.Slide>

--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -1,0 +1,275 @@
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
+import type { Image } from '@/services/django';
+import { Carousel } from '@mantine/carousel';
+import { ActionIcon } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import type { EmblaCarouselType } from 'embla-carousel';
+import { ChevronLeft, ChevronRight, Expand, X } from 'lucide-react';
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useState } from 'react';
+
+interface ItemImageCarouselProps {
+  images: Image[];
+  /** Used to build descriptive alt text for each image. */
+  itemName?: string;
+}
+
+const EMBLA_OPTIONS = { loop: true, align: 'center', containScroll: 'trimSnaps' } as const;
+
+const imageSrc = (image: Image) => image.preview || image.original;
+
+/**
+ * Image gallery for the item detail page.
+ *
+ * Renders an inline carousel with hover controls, an image counter and dot
+ * indicators, plus a full-screen lightbox. Arrow keys navigate the active
+ * carousel and Escape closes the lightbox.
+ */
+export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) => {
+  const { t } = useLanguage();
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [fullscreenOpened, fullscreen] = useDisclosure(false);
+  const [inlineApi, setInlineApi] = useState<EmblaCarouselType | null>(null);
+  const [fullscreenApi, setFullscreenApi] = useState<EmblaCarouselType | null>(null);
+
+  const hasMultiple = images.length > 1;
+
+  const scrollPrev = useCallback((api: EmblaCarouselType | null) => api?.scrollPrev(), []);
+  const scrollNext = useCallback((api: EmblaCarouselType | null) => api?.scrollNext(), []);
+
+  const openFullscreen = (index: number) => {
+    setActiveIndex(index);
+    fullscreen.open();
+  };
+
+  // Keep the lightbox carousel aligned with the active slide when it opens.
+  useEffect(() => {
+    if (fullscreenOpened) fullscreenApi?.scrollTo(activeIndex, true);
+  }, [fullscreenOpened, fullscreenApi, activeIndex]);
+
+  // Mirror the lightbox position back onto the inline carousel once closed.
+  useEffect(() => {
+    if (!fullscreenOpened) inlineApi?.scrollTo(activeIndex, true);
+  }, [fullscreenOpened, inlineApi, activeIndex]);
+
+  // The lightbox is modal, so a global listener is appropriate while it is open.
+  // Arrow keys page through the images and Escape closes the viewer.
+  useEffect(() => {
+    if (!fullscreenOpened) return;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') fullscreen.close();
+      else if (e.key === 'ArrowLeft') scrollPrev(fullscreenApi);
+      else if (e.key === 'ArrowRight') scrollNext(fullscreenApi);
+    };
+
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [fullscreenOpened, fullscreenApi, fullscreen, scrollPrev, scrollNext]);
+
+  // Inline arrow-key navigation is scoped to the gallery: it only fires while
+  // the gallery itself is focused, so it never hijacks other page interactions.
+  const handleInlineKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!hasMultiple) return;
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      scrollPrev(inlineApi);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      scrollNext(inlineApi);
+    }
+  };
+
+  if (images.length === 0) return null;
+
+  const counter = hasMultiple ? `${activeIndex + 1} / ${images.length}` : null;
+
+  return (
+    <>
+      {/* Inline gallery */}
+      <div
+        className="group relative overflow-hidden rounded-xl bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--mantine-primary-color-filled)]"
+        role="group"
+        aria-roledescription="carousel"
+        aria-label={itemName}
+        tabIndex={hasMultiple ? 0 : -1}
+        onKeyDown={handleInlineKeyDown}
+      >
+        <Carousel
+          emblaOptions={EMBLA_OPTIONS}
+          withControls={false}
+          getEmblaApi={setInlineApi}
+          onSlideChange={setActiveIndex}
+        >
+          {images.map((image, index) => (
+            <Carousel.Slide key={image.id ?? index}>
+              <button
+                type="button"
+                onClick={() => openFullscreen(index)}
+                aria-label={t('itemDetail.openImage')}
+                className="block h-64 w-full cursor-zoom-in sm:h-72 md:h-80 lg:h-96"
+              >
+                <img
+                  src={imageSrc(image)}
+                  alt={`${itemName} — ${index + 1}`}
+                  className="h-full w-full object-cover"
+                  loading={index === 0 ? 'eager' : 'lazy'}
+                />
+              </button>
+            </Carousel.Slide>
+          ))}
+        </Carousel>
+
+        {/* Counter badge */}
+        {counter && (
+          <div className="pointer-events-none absolute right-3 top-3 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white">
+            {counter}
+          </div>
+        )}
+
+        {/* Expand hint */}
+        <ActionIcon
+          variant="filled"
+          color="dark"
+          radius="xl"
+          size="lg"
+          aria-label={t('itemDetail.openImage')}
+          onClick={() => openFullscreen(activeIndex)}
+          className="absolute bottom-3 right-3 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+        >
+          <Expand size={18} />
+        </ActionIcon>
+
+        {/* Edge navigation arrows (revealed on hover / always on touch) */}
+        {hasMultiple && (
+          <>
+            <ActionIcon
+              variant="filled"
+              color="dark"
+              radius="xl"
+              size="lg"
+              aria-label={t('itemDetail.previousImage')}
+              onClick={() => scrollPrev(inlineApi)}
+              className="absolute left-3 top-1/2 -translate-y-1/2 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+            >
+              <ChevronLeft size={20} />
+            </ActionIcon>
+            <ActionIcon
+              variant="filled"
+              color="dark"
+              radius="xl"
+              size="lg"
+              aria-label={t('itemDetail.nextImage')}
+              onClick={() => scrollNext(inlineApi)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 bg-black/55 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+            >
+              <ChevronRight size={20} />
+            </ActionIcon>
+          </>
+        )}
+
+        {/* Dot indicators */}
+        {hasMultiple && (
+          <div className="absolute inset-x-0 bottom-3 flex justify-center gap-1.5">
+            {images.map((image, idx) => (
+              <button
+                key={image.id ?? idx}
+                type="button"
+                aria-label={`${t('itemDetail.goToImage')} ${idx + 1}`}
+                aria-current={activeIndex === idx}
+                onClick={() => inlineApi?.scrollTo(idx)}
+                className={cn(
+                  'h-2 rounded-full transition-all',
+                  activeIndex === idx ? 'w-5 bg-white' : 'w-2 bg-white/50 hover:bg-white/80',
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Full-screen lightbox */}
+      {fullscreenOpened && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90"
+          role="dialog"
+          aria-modal="true"
+          onClick={fullscreen.close}
+        >
+          <div className="relative h-full w-full" onClick={e => e.stopPropagation()}>
+            <Carousel
+              emblaOptions={EMBLA_OPTIONS}
+              withControls={false}
+              getEmblaApi={setFullscreenApi}
+              onSlideChange={setActiveIndex}
+              initialSlide={activeIndex}
+              className="h-full w-full"
+              styles={{ viewport: { height: '100%' }, container: { height: '100%' } }}
+            >
+              {images.map((image, index) => (
+                <Carousel.Slide
+                  key={image.id ?? index}
+                  className="flex items-center justify-center"
+                >
+                  <img
+                    src={image.original || imageSrc(image)}
+                    alt={`${itemName} — ${index + 1}`}
+                    className="max-h-[90vh] max-w-[92vw] object-contain"
+                  />
+                </Carousel.Slide>
+              ))}
+            </Carousel>
+
+            {counter && (
+              <div className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full bg-white/15 px-3 py-1 text-sm font-medium text-white backdrop-blur">
+                {counter}
+              </div>
+            )}
+
+            {hasMultiple && (
+              <>
+                <ActionIcon
+                  variant="filled"
+                  color="dark"
+                  radius="xl"
+                  size="xl"
+                  aria-label={t('itemDetail.previousImage')}
+                  onClick={() => scrollPrev(fullscreenApi)}
+                  className="absolute left-4 top-1/2 -translate-y-1/2 bg-white/15"
+                >
+                  <ChevronLeft size={28} />
+                </ActionIcon>
+                <ActionIcon
+                  variant="filled"
+                  color="dark"
+                  radius="xl"
+                  size="xl"
+                  aria-label={t('itemDetail.nextImage')}
+                  onClick={() => scrollNext(fullscreenApi)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 bg-white/15"
+                >
+                  <ChevronRight size={28} />
+                </ActionIcon>
+              </>
+            )}
+
+            <ActionIcon
+              variant="filled"
+              color="dark"
+              radius="xl"
+              size="lg"
+              aria-label={t('itemDetail.closeViewer')}
+              onClick={fullscreen.close}
+              className="absolute right-4 top-4 bg-white/15"
+            >
+              <X size={22} />
+            </ActionIcon>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ItemImageCarousel;

--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -2,7 +2,6 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import type { Image } from '@/services/django';
 import { Carousel } from '@mantine/carousel';
-import { ActionIcon } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import type { EmblaCarouselType } from 'embla-carousel';
 import { ChevronLeft, ChevronRight, Expand, X } from 'lucide-react';
@@ -161,43 +160,34 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
         )}
 
         {/* Expand hint */}
-        <ActionIcon
-          variant="filled"
-          color="dark"
-          radius="xl"
-          size="lg"
+        <button
+          type="button"
           aria-label={t('itemDetail.openImage')}
           onClick={() => openFullscreen(activeIndex)}
-          className="absolute bottom-3 right-3 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+          className="absolute bottom-3 right-3 flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white shadow-md opacity-100 transition-opacity hover:bg-black/70 md:opacity-0 md:group-hover:opacity-100"
         >
           <Expand size={18} />
-        </ActionIcon>
+        </button>
 
         {/* Edge navigation arrows (revealed on hover / always on touch) */}
         {hasMultiple && (
           <>
-            <ActionIcon
-              variant="filled"
-              color="dark"
-              radius="xl"
-              size="lg"
+            <button
+              type="button"
               aria-label={t('itemDetail.previousImage')}
               onClick={() => scrollPrev(inlineApi)}
-              className="absolute left-3 top-1/2 -translate-y-1/2 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="absolute left-3 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white shadow-md opacity-100 transition-opacity hover:bg-black/70 md:opacity-0 md:group-hover:opacity-100"
             >
               <ChevronLeft size={20} />
-            </ActionIcon>
-            <ActionIcon
-              variant="filled"
-              color="dark"
-              radius="xl"
-              size="lg"
+            </button>
+            <button
+              type="button"
               aria-label={t('itemDetail.nextImage')}
               onClick={() => scrollNext(inlineApi)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 bg-black/60 shadow-md opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
+              className="absolute right-3 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white shadow-md opacity-100 transition-opacity hover:bg-black/70 md:opacity-0 md:group-hover:opacity-100"
             >
               <ChevronRight size={20} />
-            </ActionIcon>
+            </button>
           </>
         )}
 
@@ -266,42 +256,33 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
 
             {hasMultiple && (
               <>
-                <ActionIcon
-                  variant="filled"
-                  color="dark"
-                  radius="xl"
-                  size="xl"
+                <button
+                  type="button"
                   aria-label={t('itemDetail.previousImage')}
                   onClick={() => scrollPrev(fullscreenApi)}
-                  className="absolute left-4 top-1/2 -translate-y-1/2 bg-white/15"
+                  className="absolute left-4 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25"
                 >
                   <ChevronLeft size={28} />
-                </ActionIcon>
-                <ActionIcon
-                  variant="filled"
-                  color="dark"
-                  radius="xl"
-                  size="xl"
+                </button>
+                <button
+                  type="button"
                   aria-label={t('itemDetail.nextImage')}
                   onClick={() => scrollNext(fullscreenApi)}
-                  className="absolute right-4 top-1/2 -translate-y-1/2 bg-white/15"
+                  className="absolute right-4 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25"
                 >
                   <ChevronRight size={28} />
-                </ActionIcon>
+                </button>
               </>
             )}
 
-            <ActionIcon
-              variant="filled"
-              color="dark"
-              radius="xl"
-              size="lg"
+            <button
+              type="button"
               aria-label={t('itemDetail.closeViewer')}
               onClick={fullscreen.close}
-              className="absolute right-4 top-4 bg-white/15"
+              className="absolute right-4 top-4 flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25"
             >
               <X size={22} />
-            </ActionIcon>
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/components/items/RentalCalendar.tsx
+++ b/frontend/src/components/items/RentalCalendar.tsx
@@ -580,7 +580,7 @@ export const RentalCalendar = ({
           p="md"
           radius="lg"
           withBorder
-          bg="green.0"
+          bg="var(--mantine-color-green-light)"
           className="relative flex flex-wrap items-center justify-between gap-3"
         >
           <div>
@@ -612,7 +612,14 @@ export const RentalCalendar = ({
 
       {/* Selection Summary */}
       {!selectingStart && selectedStart && selectedEnd && (
-        <Paper mt="md" p="md" radius="lg" bg="gray.1" className="relative">
+        <Paper
+          mt="md"
+          p="md"
+          radius="lg"
+          withBorder
+          bg="var(--mantine-color-default-hover)"
+          className="relative"
+        >
           <Text size="sm" fw={500} mb={4}>
             {t('calendar.selectedPeriod')}:
           </Text>

--- a/frontend/src/components/items/RentalCalendar.tsx
+++ b/frontend/src/components/items/RentalCalendar.tsx
@@ -85,7 +85,10 @@ export const RentalCalendar = ({
   // All dates use the browser's local timezone
   // JavaScript Date objects automatically work in the user's timezone
   const [currentDate, setCurrentDate] = useState(new Date());
+  // First click of a range selection (a datetime in weekly view, a day in monthly).
   const [selectingStart, setSelectingStart] = useState<Date | null>(null);
+  // Tile currently under the pointer while a start is pending — drives the live preview.
+  const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
 
   const currentWeekStart = useMemo(() => startOfDay(currentDate), [currentDate]);
 
@@ -124,7 +127,9 @@ export const RentalCalendar = ({
     const dayStart = startOfDay(day);
 
     if (!selectingStart) {
+      // First click: mark the start tile and wait for the end.
       setSelectingStart(dayStart);
+      setHoveredDate(dayStart);
     } else {
       const start = isBefore(dayStart, selectingStart) ? dayStart : selectingStart;
       const end = isBefore(dayStart, selectingStart) ? selectingStart : dayStart;
@@ -132,6 +137,7 @@ export const RentalCalendar = ({
 
       onDateRangeSelect?.(start, adjustedEnd);
       setSelectingStart(null);
+      setHoveredDate(null);
     }
   };
 
@@ -146,8 +152,9 @@ export const RentalCalendar = ({
     }
 
     if (!selectingStart) {
-      // Start selection
+      // First click: mark the start slot and wait for the end.
       setSelectingStart(selectedDateTime);
+      setHoveredDate(selectedDateTime);
     } else {
       // Check if clicking the same slot - select just one hour
       if (selectedDateTime.getTime() === selectingStart.getTime()) {
@@ -155,6 +162,7 @@ export const RentalCalendar = ({
         endDateTime.setHours(hour + 1, 0, 0, 0);
         onDateRangeSelect?.(selectedDateTime, endDateTime);
         setSelectingStart(null);
+        setHoveredDate(null);
         return;
       }
 
@@ -168,6 +176,7 @@ export const RentalCalendar = ({
 
       onDateRangeSelect?.(start, adjustedEnd);
       setSelectingStart(null);
+      setHoveredDate(null);
     }
   };
 
@@ -183,18 +192,24 @@ export const RentalCalendar = ({
     );
   };
 
-  const isTimeSlotInPreview = (date: Date, hour: number): boolean => {
+  const isTimeSlotPendingStart = (date: Date, hour: number): boolean => {
     if (!selectingStart) return false;
+    const slotStart = new Date(date);
+    slotStart.setHours(hour, 0, 0, 0);
+    return slotStart.getTime() === selectingStart.getTime();
+  };
+
+  // Light highlight for the tiles between the pending start and the hovered tile.
+  const isTimeSlotInPreview = (date: Date, hour: number): boolean => {
+    if (!selectingStart || !hoveredDate) return false;
 
     const slotStart = new Date(date);
     slotStart.setHours(hour, 0, 0, 0);
 
-    const start = selectingStart;
-    const end = slotStart;
+    const [start, end] = isBefore(hoveredDate, selectingStart)
+      ? [hoveredDate, selectingStart]
+      : [selectingStart, hoveredDate];
 
-    if (isBefore(end, start)) {
-      return isWithinInterval(slotStart, { start: end, end: start });
-    }
     return isWithinInterval(slotStart, { start, end });
   };
 
@@ -258,15 +273,20 @@ export const RentalCalendar = ({
     });
   };
 
-  const isDayInPreview = (day: Date): boolean => {
+  const isDayPendingStart = (day: Date): boolean => {
     if (!selectingStart) return false;
-    const dayStart = startOfDay(day);
-    const start = selectingStart;
-    const end = dayStart;
+    return startOfDay(day).getTime() === selectingStart.getTime();
+  };
 
-    if (isBefore(end, start)) {
-      return isWithinInterval(dayStart, { start: end, end: start });
-    }
+  // Light highlight for the days between the pending start and the hovered day.
+  const isDayInPreview = (day: Date): boolean => {
+    if (!selectingStart || !hoveredDate) return false;
+    const dayStart = startOfDay(day);
+
+    const [start, end] = isBefore(hoveredDate, selectingStart)
+      ? [hoveredDate, selectingStart]
+      : [selectingStart, hoveredDate];
+
     return isWithinInterval(dayStart, { start, end });
   };
 
@@ -303,8 +323,33 @@ export const RentalCalendar = ({
     });
   };
 
+  const clearSelection = () => {
+    setSelectingStart(null);
+    setHoveredDate(null);
+  };
+
+  const formatDurationLabel = (start: Date, end: Date) => {
+    const hours = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60));
+    if (viewMode === 'monthly') {
+      return `${Math.max(1, Math.round(hours / 24))} ${t('calendar.days')}`;
+    }
+    return `${hours} ${t('calendar.hours')}`;
+  };
+
+  // Live range while a start is pending: ordered start/end plus the unit padding
+  // (a full hour in weekly view, a full day in monthly) used for the final booking.
+  const previewRange = useMemo(() => {
+    if (!selectingStart || !hoveredDate) return null;
+    const [start, last] = isBefore(hoveredDate, selectingStart)
+      ? [hoveredDate, selectingStart]
+      : [selectingStart, hoveredDate];
+    const end =
+      viewMode === 'weekly' ? new Date(last.getTime() + 60 * 60 * 1000) : addDays(last, 1);
+    return { start, end };
+  }, [selectingStart, hoveredDate, viewMode]);
+
   const renderWeeklyView = () => (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto" onMouseLeave={() => selectingStart && setHoveredDate(null)}>
       <div className="min-w-[700px]">
         {/* Week Day Headers */}
         <div className="grid grid-cols-8 gap-1 mb-2">
@@ -336,14 +381,22 @@ export const RentalCalendar = ({
                 const isPast = isTimeSlotPast(day, hour);
                 const isBooked = isTimeSlotBooked(day, hour);
                 const booking = isBooked ? getBookingForTimeSlot(day, hour) : null;
-                const isSelected = isTimeSlotSelected(day, hour);
-                const isPreview = isTimeSlotInPreview(day, hour);
+                const isPendingStart = isTimeSlotPendingStart(day, hour);
+                // Hide the previously confirmed range while a new selection is in progress.
+                const isSelected = !selectingStart && isTimeSlotSelected(day, hour);
+                const isPreview = isTimeSlotInPreview(day, hour) && !isPendingStart;
                 const isClickDisabled = isPast || isBooked;
+                const isHighlighted = isSelected || isPendingStart;
 
                 const slotButton = (
                   <button
                     key={dayIndex}
                     onClick={() => !isClickDisabled && handleTimeSlotClick(day, hour)}
+                    onMouseEnter={() => {
+                      const slot = new Date(day);
+                      slot.setHours(hour, 0, 0, 0);
+                      if (selectingStart && !isClickDisabled) setHoveredDate(slot);
+                    }}
                     disabled={isPast && !isBooked}
                     className={cn(
                       'h-8 rounded transition-colors w-full',
@@ -352,13 +405,12 @@ export const RentalCalendar = ({
                         !isPast &&
                         'bg-[var(--mantine-color-red-1)] cursor-pointer opacity-70 border border-[var(--mantine-color-red-3)]',
                       !isClickDisabled &&
-                        !isSelected &&
+                        !isHighlighted &&
                         !isPreview &&
                         'bg-transparent hover:bg-[var(--mantine-color-gray-1)] border',
-                      isSelected &&
+                      isHighlighted &&
                         'bg-[var(--mantine-color-green-6)] text-white hover:bg-[var(--mantine-color-green-7)]',
                       isPreview &&
-                        !isSelected &&
                         'bg-[var(--mantine-color-green-2)] hover:bg-[var(--mantine-color-green-3)]',
                     )}
                   />
@@ -405,19 +457,28 @@ export const RentalCalendar = ({
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-1">
+      <div
+        className="grid grid-cols-7 gap-1"
+        onMouseLeave={() => selectingStart && setHoveredDate(null)}
+      >
         {daysInMonthGrid.map((day, index) => {
           const isPast = isDayPast(day);
           const isBooked = isDayBooked(day);
           const bookings = isBooked ? getBookingsForDay(day) : [];
-          const isSelected = isDaySelected(day);
-          const isPreview = isDayInPreview(day);
+          const isPendingStart = isDayPendingStart(day);
+          // Hide the previously confirmed range while a new selection is in progress.
+          const isSelected = !selectingStart && isDaySelected(day);
+          const isPreview = isDayInPreview(day) && !isPendingStart;
           const isCurrentMonth = isSameMonth(day, currentDate);
           const isClickDisabled = isPast || isBooked;
+          const isHighlighted = isSelected || isPendingStart;
 
           const dayButton = (
             <button
               onClick={() => !isClickDisabled && handleDayClick(day)}
+              onMouseEnter={() => {
+                if (selectingStart && !isClickDisabled) setHoveredDate(startOfDay(day));
+              }}
               disabled={isPast && !isBooked}
               className={cn(
                 'h-16 rounded transition-colors flex flex-col items-center justify-center p-1 w-full',
@@ -427,16 +488,15 @@ export const RentalCalendar = ({
                   !isPast &&
                   'bg-[var(--mantine-color-red-1)] cursor-pointer opacity-70 border border-[var(--mantine-color-red-3)]',
                 !isClickDisabled &&
-                  !isSelected &&
+                  !isHighlighted &&
                   !isPreview &&
                   'bg-transparent hover:bg-[var(--mantine-color-gray-1)] border',
-                isSelected &&
+                isHighlighted &&
                   'bg-[var(--mantine-color-green-6)] text-white hover:bg-[var(--mantine-color-green-7)]',
                 isPreview &&
-                  !isSelected &&
                   'bg-[var(--mantine-color-green-2)] hover:bg-[var(--mantine-color-green-3)]',
                 isSameDay(day, new Date()) &&
-                  !isSelected &&
+                  !isHighlighted &&
                   'border-2 border-[var(--mantine-color-green-6)]',
               )}
             >
@@ -513,8 +573,45 @@ export const RentalCalendar = ({
 
       {viewMode === 'weekly' ? renderWeeklyView() : renderMonthlyView()}
 
+      {/* Live preview while a start tile is selected and an end is being chosen */}
+      {selectingStart && (
+        <Paper
+          mt="md"
+          p="md"
+          radius="lg"
+          withBorder
+          bg="green.0"
+          className="relative flex flex-wrap items-center justify-between gap-3"
+        >
+          <div>
+            <Text size="sm" fw={500} mb={4}>
+              {t('calendar.selectingPeriod')}
+            </Text>
+            {previewRange ? (
+              <>
+                <Text size="sm" c="dimmed">
+                  {format(previewRange.start, 'EEE, MMM d, HH:mm')} –{' '}
+                  {format(previewRange.end, 'EEE, MMM d, HH:mm')}
+                </Text>
+                <Text size="sm" fw={600} mt={2}>
+                  {t('calendar.duration')}:{' '}
+                  {formatDurationLabel(previewRange.start, previewRange.end)}
+                </Text>
+              </>
+            ) : (
+              <Text size="sm" c="dimmed">
+                {t('calendar.clickToSetEnd')}
+              </Text>
+            )}
+          </div>
+          <Button size="xs" variant="subtle" color="gray" onClick={clearSelection}>
+            {t('calendar.clearSelection')}
+          </Button>
+        </Paper>
+      )}
+
       {/* Selection Summary */}
-      {selectedStart && selectedEnd && (
+      {!selectingStart && selectedStart && selectedEnd && (
         <Paper mt="md" p="md" radius="lg" bg="gray.1" className="relative">
           <Text size="sm" fw={500} mb={4}>
             {t('calendar.selectedPeriod')}:

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -315,6 +315,10 @@ const translations = {
     'calendar.to': 'To',
     'calendar.duration': 'Duration',
     'calendar.hours': 'hours',
+    'calendar.days': 'days',
+    'calendar.selectingPeriod': 'Selecting period',
+    'calendar.clickToSetEnd': 'Click an end tile to confirm, or hover to preview',
+    'calendar.clearSelection': 'Clear',
     'calendar.week': 'Week',
     'calendar.month': 'Month',
 
@@ -883,6 +887,11 @@ const translations = {
     'calendar.to': 'Bis',
     'calendar.duration': 'Dauer',
     'calendar.hours': 'Stunden',
+    'calendar.days': 'Tage',
+    'calendar.selectingPeriod': 'Zeitraum wählen',
+    'calendar.clickToSetEnd':
+      'Klicke ein End-Feld zum Bestätigen oder bewege die Maus für eine Vorschau',
+    'calendar.clearSelection': 'Zurücksetzen',
     'calendar.week': 'Woche',
     'calendar.month': 'Monat',
 

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -409,6 +409,11 @@ const translations = {
     'itemDetail.notFound': 'Item not found',
     'itemDetail.availability': 'Availability',
     'itemDetail.properties': 'Properties',
+    'itemDetail.previousImage': 'Previous image',
+    'itemDetail.nextImage': 'Next image',
+    'itemDetail.openImage': 'Open image in full screen',
+    'itemDetail.closeViewer': 'Close image viewer',
+    'itemDetail.goToImage': 'Go to image',
 
     // My Items
     'myItems.title': 'My Items',
@@ -973,6 +978,11 @@ const translations = {
     'itemDetail.notFound': 'Artikel nicht gefunden',
     'itemDetail.availability': 'Verfügbarkeit',
     'itemDetail.properties': 'Eigenschaften',
+    'itemDetail.previousImage': 'Vorheriges Bild',
+    'itemDetail.nextImage': 'Nächstes Bild',
+    'itemDetail.openImage': 'Bild im Vollbild öffnen',
+    'itemDetail.closeViewer': 'Bildansicht schließen',
+    'itemDetail.goToImage': 'Zu Bild springen',
 
     // My Items
     'myItems.title': 'Meine Artikel',

--- a/frontend/src/pages/ItemDetail.tsx
+++ b/frontend/src/pages/ItemDetail.tsx
@@ -1,4 +1,5 @@
 import { BookingDialog } from '@/components/items/BookingDialog';
+import { ItemImageCarousel } from '@/components/items/ItemImageCarousel';
 import { RentalCalendar } from '@/components/items/RentalCalendar';
 import {
   getSalesTypeBadgeProps,
@@ -15,25 +16,12 @@ import { useItemCollections } from '@/hooks/useCollections';
 import { convertLineBreaks } from '@/lib/convertLineBreaks';
 import { formatPrice } from '@/lib/currency';
 import { cn } from '@/lib/utils';
-import { SalesTypeEnum } from '@/services/django';
+import { getCategoryIcon } from '@/lib/categoryIcons';
 import { ActionIcon, Badge, Button, Text, Tooltip } from '@mantine/core';
-import { Carousel } from '@mantine/carousel';
 import { modals } from '@mantine/modals';
 import { formatDistanceToNow } from 'date-fns';
-import type { EmblaCarouselType } from 'embla-carousel';
-import { getCategoryIcon } from '@/lib/categoryIcons';
-import {
-  ArrowLeft,
-  BookMarked,
-  Calendar,
-  ChevronLeft,
-  ChevronRight,
-  Edit3,
-  Trash2,
-  X,
-  Zap,
-} from 'lucide-react';
-import { createElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, BookMarked, Calendar, Edit3, Trash2, Zap } from 'lucide-react';
+import { createElement, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const ItemDetail = () => {
@@ -45,24 +33,17 @@ const ItemDetail = () => {
   const deleteItemMutation = useDeleteItem();
   const { data: itemCollections } = useItemCollections(user ? itemUuid : undefined);
 
-  const [showAllImages, setShowAllImages] = useState(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date | undefined>();
   const [selectedEndDate, setSelectedEndDate] = useState<Date | undefined>();
   const [showBookingDialog, setShowBookingDialog] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
 
-  // embla apis exposed by Mantine Carousel - configure for single full-width slide (no peek)
-  const emblaOptions = { loop: false, align: 'center', containScroll: 'trimSnaps' } as const;
-  const [emblaApi, setEmblaApi] = useState<EmblaCarouselType | null>(null);
-  const [emblaFsApi, setEmblaFsApi] = useState<EmblaCarouselType | null>(null);
+  const location = useLocation();
+  const rentalCalendarRef = useRef<HTMLDivElement | null>(null);
 
-  // open fullscreen viewer at a given index
-  const openFullscreen = (index: number) => {
-    setActiveIndex(index);
-    setShowAllImages(true);
-    // try to scroll fullscreen embla immediately if available
-    if (emblaFsApi) emblaFsApi.scrollTo(index);
-  };
+  const isOwner = useMemo(() => {
+    if (!user || !item) return false;
+    return item.user === user.id;
+  }, [user, item]);
 
   const handleDateRangeSelect = (start: Date, end: Date) => {
     setSelectedStartDate(start);
@@ -75,33 +56,18 @@ const ItemDetail = () => {
     setShowBookingDialog(true);
   };
 
-  const isOwner = useMemo(() => {
-    if (!user || !item) return false;
-    return item.user === user.id;
-  }, [user, item]);
-
-  const location = useLocation();
-  const rentalCalendarRef = useRef<HTMLDivElement | null>(null);
-
-  // If the URL contains #booking, scroll to the start of the booking calendar and open booking UI
+  // If the URL contains #booking, scroll to the booking calendar and reveal it.
   useEffect(() => {
-    const hash = location.hash;
-    if (hash === '#booking' && rentalCalendarRef.current) {
-      try {
-        rentalCalendarRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      } catch {
-        // ignore
-      }
+    if (location.hash === '#booking' && rentalCalendarRef.current) {
+      rentalCalendarRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
       history.replaceState(null, '', location.pathname + location.search);
     }
-  }, [location.hash]);
+  }, [location.hash, location.pathname, location.search]);
 
   const handleDelete = async () => {
     if (!item) return;
     await deleteItemMutation.mutateAsync(item.id, {
-      onSuccess: () => {
-        navigate('/my-items');
-      },
+      onSuccess: () => navigate('/my-items'),
     });
   };
 
@@ -111,70 +77,25 @@ const ItemDetail = () => {
       children: <Text size="sm">{t('itemDetail.deleteConfirmDescription')}</Text>,
       labels: { confirm: t('common.delete'), cancel: t('common.cancel') },
       confirmProps: { color: 'red' },
-      onConfirm: () => {
-        void handleDelete();
-      },
+      onConfirm: () => void handleDelete(),
     });
-
-  // when opening fullscreen, ensure fullscreen embla is on the correct slide
-  useEffect(() => {
-    if (showAllImages && typeof activeIndex === 'number' && emblaFsApi) {
-      emblaFsApi.scrollTo(activeIndex);
-    }
-  }, [showAllImages, activeIndex, emblaFsApi]);
-
-  const scrollPrev = useCallback((api: EmblaCarouselType | null) => api?.scrollPrev(), []);
-  const scrollNext = useCallback((api: EmblaCarouselType | null) => api?.scrollNext(), []);
-
-  // keyboard navigation: left/right arrows control the current visible carousel
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || (target && target.isContentEditable)) return;
-      if (e.key === 'Escape' || e.key === 'Esc') {
-        // close fullscreen preview
-        setShowAllImages(false);
-        return;
-      }
-      if (e.key === 'ArrowLeft') {
-        if (showAllImages) scrollPrev(emblaFsApi);
-        else scrollPrev(emblaApi);
-      } else if (e.key === 'ArrowRight') {
-        if (showAllImages) scrollNext(emblaFsApi);
-        else scrollNext(emblaApi);
-      }
-    };
-
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [emblaApi, emblaFsApi, showAllImages, scrollPrev, scrollNext]);
 
   if (isLoading) {
     return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="text-center">{t('common.loading')}</div>
+      <div className="container mx-auto px-4 py-8 text-center text-[var(--mantine-color-dimmed)]">
+        {t('common.loading')}
       </div>
     );
   }
 
-  if (error) {
+  if (error || !item) {
     return (
-      <div className="min-h-screen bg-background text-center py-10">
-        <Text c="red">{error.message}</Text>
-        <Button component={Link} to="/" mt="md">
-          Back to Home
-        </Button>
-      </div>
-    );
-  }
-
-  if (!item) {
-    return (
-      <div className="min-h-screen bg-background text-center py-10">
-        <p>Item not found.</p>
-        <Button component={Link} to="/" mt="md">
-          Back to Home
+      <div className="container mx-auto px-4 py-16 text-center">
+        <Text c={error ? 'red' : undefined}>
+          {error ? error.message : t('itemDetail.notFound')}
+        </Text>
+        <Button component={Link} to="/" mt="md" variant="light">
+          {t('common.back')}
         </Button>
       </div>
     );
@@ -194,207 +115,175 @@ const ItemDetail = () => {
 
   const isRental = sales_type === 'rent' || sales_type === 'borrow';
   const isWanted = sales_type === 'want_buy' || sales_type === 'want_rent';
+  const hasImages = images.length > 0;
 
   const conditionMap: Record<number, string> = {
     0: t('condition.new'),
     1: t('condition.used'),
     2: t('condition.broken'),
   };
+  const conditionLabel =
+    (condition !== undefined ? conditionMap[condition] : undefined) ?? t('condition.unknown');
 
-  function getConditionLabel(conditionId: number | undefined) {
-    if (conditionId !== undefined) {
-      return conditionMap[conditionId];
+  const properties = Object.entries(
+    (item.properties && typeof item.properties === 'object' && !Array.isArray(item.properties)
+      ? item.properties
+      : {}) as Record<string, unknown>,
+  )
+    .filter(([key]) => key !== 'metadata')
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  // Booking action: label + whether it is disabled for the current viewer.
+  const actionLabel = (() => {
+    switch (sales_type) {
+      case 'rent':
+        return t('itemDetail.rentNow');
+      case 'borrow':
+        return t('itemDetail.borrowNow');
+      case 'donate':
+        return t('itemDetail.requestDonate');
+      case 'want_buy':
+      case 'want_rent':
+        return t('itemDetail.contactOwner');
+      default:
+        return t('itemDetail.buyNow');
     }
-    return t('condition.unknown');
-  }
+  })();
+
+  const buyingAllowed = item.status === 2 || item.status === 3; // 2 = available, 3 = reserved
+  const bookingDisabled =
+    !user ||
+    (isWanted
+      ? false
+      : (isOwner && !!price && !isRental) || (!buyingAllowed && !!price && !isRental));
+  const showBookingAction = !isOwner || isRental || isWanted;
+
+  const formatPropertyValue = (value: unknown) => {
+    if (value === null || value === undefined) return '—';
+    if (Array.isArray(value)) return value.join(', ');
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  };
+
+  const bookingDialog = (
+    <BookingDialog
+      itemUuid={item.id}
+      itemName={name}
+      price={price}
+      priceCurrency={price_currency || undefined}
+      salesType={sales_type}
+      rentalOpenEnd={item.rental_open_end ?? false}
+      preselectedStartDate={selectedStartDate}
+      preselectedEndDate={selectedEndDate}
+      controlledOpen={showBookingDialog}
+      onControlledOpenChange={setShowBookingDialog}
+      triggerLabel={actionLabel}
+      disabled={bookingDisabled}
+    />
+  );
 
   return (
-    <>
-      <div className="container mx-auto max-w-4xl px-4 py-8">
-        <Button
-          variant="subtle"
-          onClick={() => navigate(-1)}
-          mb="md"
-          leftSection={<ArrowLeft size={16} />}
-        >
-          {t('common.back')}
-        </Button>
+    <div className="container mx-auto max-w-4xl px-4 py-8">
+      <Button
+        variant="subtle"
+        onClick={() => navigate(-1)}
+        mb="lg"
+        leftSection={<ArrowLeft size={16} />}
+      >
+        {t('common.back')}
+      </Button>
 
-        <div
-          className={cn(
-            'grid gap-8',
-            images.length > 0 ? 'grid-cols-1 md:grid-cols-2' : 'grid-cols-1',
+      <div className={cn('grid gap-8', hasImages ? 'md:grid-cols-2' : 'grid-cols-1')}>
+        {hasImages && <ItemImageCarousel images={images} itemName={name} />}
+
+        {/* Item details */}
+        <div className="flex flex-col gap-6">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge leftSection={createElement(getCategoryIcon(category), { size: 14 })}>
+                {t(`categories.${category}`)}
+              </Badge>
+              <Badge variant="light" color="gray">
+                {conditionLabel}
+              </Badge>
+              {item.status !== undefined && item.status !== null && (
+                <Badge color={getStatusMantineColor(item.status)}>
+                  {getStatusLabel(item.status) ? t(`status.${getStatusLabel(item.status)}`) : ''}
+                </Badge>
+              )}
+              {sales_type && (
+                <Badge {...getSalesTypeBadgeProps(sales_type)}>
+                  {t(`item.salesType.badge.${sales_type}`)}
+                </Badge>
+              )}
+              {item.rental_self_service && (
+                <Tooltip
+                  multiline
+                  w={240}
+                  label={
+                    <div>
+                      <Text size="sm" fw={500}>
+                        {t('item.instantRental')}
+                      </Text>
+                      <Text size="xs">{t('item.instantRentalTooltip')}</Text>
+                    </div>
+                  }
+                >
+                  <Badge color="yellow" className="cursor-default">
+                    <Zap size={12} className="fill-current block" />
+                  </Badge>
+                </Tooltip>
+              )}
+            </div>
+
+            <h1 className="text-3xl font-bold leading-tight">{name}</h1>
+
+            <Text component="div" size="sm" c="dimmed" className="flex items-center gap-2">
+              <Calendar size={16} />
+              <span>
+                {t('itemDetail.listed')}{' '}
+                {formatDistanceToNow(new Date(created_at), { addSuffix: true })}
+              </span>
+            </Text>
+
+            {price && (
+              <p className="text-2xl font-bold">
+                {formatPrice(price, price_currency)}
+                {isRental && (
+                  <span className="ml-1 text-base font-normal">{t('time.perHour')}</span>
+                )}
+              </p>
+            )}
+          </div>
+
+          {description !== undefined && description !== '' && (
+            <Text c="dimmed">{convertLineBreaks(description)}</Text>
           )}
-        >
-          {/* Image Carousel - only show if there are images */}
-          {images.length > 0 ? (
-            <div className="relative">
-              <Carousel
-                emblaOptions={emblaOptions}
-                withControls={false}
-                getEmblaApi={setEmblaApi}
-                onSlideChange={setActiveIndex}
-              >
-                {images.map((image, index) => (
-                  <Carousel.Slide key={index}>
-                    {/* reduced thumbnail height; smaller on mobile, larger on desktop */}
-                    <div className="w-full h-40 md:h-56 lg:h-72 overflow-hidden rounded-lg relative">
-                      <img
-                        src={image.preview || image.original}
-                        alt={`${name} ${index + 1}`}
-                        className="w-full h-full object-cover cursor-pointer"
-                        onClick={() => openFullscreen(index)}
-                      />
-                    </div>
-                  </Carousel.Slide>
-                ))}
-              </Carousel>
-              {/* navigation: arrows (left) and dots (center) on same horizontal row */}
-              {images.length > 1 && (
-                <div className="mt-2 flex items-center w-full">
-                  <div className="flex items-center gap-2">
-                    <ActionIcon
-                      variant="default"
-                      size="lg"
-                      onClick={() => scrollPrev(emblaApi)}
-                      aria-label="Previous image"
-                    >
-                      <ChevronLeft size={20} />
-                    </ActionIcon>
-                    <ActionIcon
-                      variant="default"
-                      size="lg"
-                      onClick={() => scrollNext(emblaApi)}
-                      aria-label="Next image"
-                    >
-                      <ChevronRight size={20} />
-                    </ActionIcon>
-                  </div>
 
-                  <div className="flex-1 flex justify-center">
-                    <div className="flex items-center gap-2">
-                      {images.map((_, idx) => (
-                        <button
-                          key={idx}
-                          aria-label={`Go to image ${idx + 1}`}
-                          onClick={() => emblaApi && emblaApi.scrollTo(idx)}
-                          className={`h-2 w-2 rounded-full ${
-                            activeIndex === idx
-                              ? 'bg-[var(--mantine-color-green-6)]'
-                              : 'bg-gray-300'
-                          }`}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          ) : null}
-
-          {/* Item Details */}
-          <div className="space-y-6">
+          {properties.length > 0 && (
             <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-4">
-                <Badge leftSection={createElement(getCategoryIcon(category), { size: 14 })}>
-                  {t(`categories.${category}`)}
-                </Badge>
-                <Badge variant="light" color="gray">
-                  {getConditionLabel(condition)}
-                </Badge>
-                {typeof item.status !== 'undefined' && item.status !== null && (
-                  <Badge color={getStatusMantineColor(item.status)}>
-                    {getStatusLabel(item.status) ? t(`status.${getStatusLabel(item.status)}`) : ''}
-                  </Badge>
-                )}
-                {sales_type && (
-                  <Badge {...getSalesTypeBadgeProps(sales_type)}>
-                    {t(`item.salesType.badge.${sales_type}`)}
-                  </Badge>
-                )}
-                {item.rental_self_service && (
-                  <Tooltip
-                    multiline
-                    w={240}
-                    label={
-                      <div>
-                        <Text size="sm" fw={500}>
-                          {t('item.instantRental')}
-                        </Text>
-                        <Text size="xs">{t('item.instantRentalTooltip')}</Text>
-                      </div>
-                    }
-                  >
-                    <Badge color="yellow" className="cursor-default">
-                      <Zap size={12} className="fill-current block" />
-                    </Badge>
-                  </Tooltip>
-                )}
-              </div>
-              <h1 className="text-3xl font-bold">{name}</h1>
-              <Text component="div" size="sm" c="dimmed" className="flex items-center gap-2">
-                <Calendar size={16} />
-                <span>
-                  {t('itemDetail.listed')}{' '}
-                  {formatDistanceToNow(new Date(created_at), {
-                    addSuffix: true,
-                  })}
-                </span>
+              <Text size="sm" fw={600} c="dimmed" tt="uppercase" className="tracking-wide">
+                {t('itemDetail.properties')}
               </Text>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+                {properties.map(([key, value]) => (
+                  <div key={key} className="contents">
+                    <dt className="font-medium capitalize text-[var(--mantine-color-dimmed)]">
+                      {key}
+                    </dt>
+                    <dd className="break-words">{formatPropertyValue(value)}</dd>
+                  </div>
+                ))}
+              </dl>
             </div>
+          )}
 
-            <div className="space-y-4">
-              {price && (
-                <p className="text-2xl font-bold">
-                  {formatPrice(price, price_currency)}
-                  {isRental && (
-                    <span className="text-base font-normal ml-1">{t('time.perHour')}</span>
-                  )}
-                </p>
-              )}
-            </div>
+          {/* Owner details are shown to logged-in users only */}
+          {user && <UserInfoBox userUuid={item.user} />}
 
-            <Text c="dimmed">{description !== undefined && convertLineBreaks(description)}</Text>
-
-            {/* Properties */}
-            {item.properties &&
-            typeof item.properties === 'object' &&
-            !Array.isArray(item.properties) &&
-            Object.keys(item.properties).length > 0 ? (
-              <div className="space-y-2">
-                <Text size="sm" fw={600} c="dimmed" tt="uppercase" className="tracking-wide">
-                  {t('itemDetail.properties')}
-                </Text>
-                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
-                  {Object.entries(item.properties as Record<string, unknown>)
-                    .filter(([key]) => key !== 'metadata')
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([key, value]) => (
-                      <div key={key} className="contents">
-                        <dt className="font-medium capitalize text-[var(--mantine-color-dimmed)]">
-                          {key}
-                        </dt>
-                        <dd className="break-words">
-                          {value === null || value === undefined
-                            ? '—'
-                            : Array.isArray(value)
-                              ? value.join(', ')
-                              : typeof value === 'object'
-                                ? JSON.stringify(value)
-                                : String(value)}
-                        </dd>
-                      </div>
-                    ))}
-                </dl>
-              </div>
-            ) : null}
-
-            {/* Show owner details to logged-in users only */}
-            {user && <UserInfoBox userUuid={item.user} />}
-
-            {/* Action Buttons */}
-            <div className="flex items-center gap-2 pt-4">
-              {/* Owner controls: edit & delete */}
+          {/* Action buttons */}
+          {(isOwner || showBookingAction) && (
+            <div className="flex flex-wrap items-center gap-2 pt-2">
               {isOwner && (
                 <>
                   <ActionIcon
@@ -418,188 +307,58 @@ const ItemDetail = () => {
                 </>
               )}
 
-              {/* Booking dialog: show for non-owners, and also for owners when rentable; always for wanted items */}
-              {(!isOwner || isRental || isWanted) && (
-                <div className={isOwner ? 'ml-2' : ''}>
-                  <div>
-                    {(() => {
-                      const buyingAllowed = item.status === 2 || item.status === 3; // 2 = available, 3 = reserved
-
-                      // Wanted items: no price/availability guard — the viewer is offering to the lister
-                      const isDisabled =
-                        !user ||
-                        (isWanted
-                          ? false
-                          : (isOwner && !!price && !isRental) ||
-                            (!buyingAllowed && !!price && !isRental));
-
-                      const actionLabel = (() => {
-                        switch (sales_type) {
-                          case 'rent':
-                            return t('itemDetail.rentNow');
-                          case 'borrow':
-                            return t('itemDetail.borrowNow');
-                          case 'donate':
-                            return t('itemDetail.requestDonate');
-                          case 'want_buy':
-                          case 'want_rent':
-                            return t('itemDetail.contactOwner');
-                          default:
-                            return t('itemDetail.buyNow');
-                        }
-                      })();
-
-                      const dialog = (
-                        <BookingDialog
-                          itemUuid={item.id}
-                          itemName={name}
-                          price={price}
-                          priceCurrency={price_currency || undefined}
-                          salesType={sales_type}
-                          rentalOpenEnd={item.rental_open_end ?? false}
-                          preselectedStartDate={selectedStartDate}
-                          preselectedEndDate={selectedEndDate}
-                          controlledOpen={showBookingDialog}
-                          onControlledOpenChange={setShowBookingDialog}
-                          triggerLabel={actionLabel}
-                          disabled={isDisabled}
-                        />
-                      );
-
-                      if (!user) {
-                        return (
-                          <Tooltip label={t('auth.loginRequired')}>
-                            <span className="inline-block">{dialog}</span>
-                          </Tooltip>
-                        );
-                      }
-
-                      return dialog;
-                    })()}
-                  </div>
-                </div>
-              )}
+              {showBookingAction &&
+                (user ? (
+                  bookingDialog
+                ) : (
+                  <Tooltip label={t('auth.loginRequired')}>
+                    <span className="inline-block">{bookingDialog}</span>
+                  </Tooltip>
+                ))}
             </div>
+          )}
 
-            {/* Add to collection — always shown to logged-in users */}
-            {user && <AddToCollectionPopover itemId={item.id} />}
+          {/* Add to collection — always shown to logged-in users */}
+          {user && <AddToCollectionPopover itemId={item.id} />}
 
-            {/* Collections this item appears in — only shown to logged-in users */}
-            {user && itemCollections && itemCollections.length > 0 && (
-              <div className="space-y-2 pt-2">
-                <Text component="div" size="sm" c="dimmed" className="flex items-center gap-2">
-                  <BookMarked size={16} />
-                  <span>{t('collections.appearsIn')}</span>
-                </Text>
-                <div className="flex flex-wrap gap-2">
-                  {itemCollections.map(col => (
-                    <Link
-                      key={col.id}
-                      to={`/collections/${col.id}`}
-                      onClick={e => e.stopPropagation()}
-                    >
-                      <Badge variant="light" color="gray" className="cursor-pointer">
-                        {col.name}
-                      </Badge>
-                    </Link>
-                  ))}
-                </div>
+          {/* Collections this item appears in */}
+          {user && itemCollections && itemCollections.length > 0 && (
+            <div className="space-y-2">
+              <Text component="div" size="sm" c="dimmed" className="flex items-center gap-2">
+                <BookMarked size={16} />
+                <span>{t('collections.appearsIn')}</span>
+              </Text>
+              <div className="flex flex-wrap gap-2">
+                {itemCollections.map(col => (
+                  <Link
+                    key={col.id}
+                    to={`/collections/${col.id}`}
+                    onClick={e => e.stopPropagation()}
+                  >
+                    <Badge variant="light" color="gray" className="cursor-pointer">
+                      {col.name}
+                    </Badge>
+                  </Link>
+                ))}
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
-
-        {/* Rental Calendar - Only show for rental items and logged-in users */}
-        {isRental && !!user && (
-          <div className="mt-8" id="booking" ref={rentalCalendarRef}>
-            <RentalCalendar
-              itemUuid={itemUuid}
-              onDateRangeSelect={handleDateRangeSelect}
-              selectedStart={selectedStartDate}
-              selectedEnd={selectedEndDate}
-              onBookNow={handleBookNowFromCalendar}
-            />
-          </div>
-        )}
       </div>
 
-      {/* Full-screen image viewer */}
-      {showAllImages && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80"
-          onClick={() => setShowAllImages(false)}
-        >
-          <div
-            className="relative w-full h-full max-w-4xl max-h-4xl"
-            onClick={e => e.stopPropagation()}
-          >
-            <Carousel
-              emblaOptions={emblaOptions}
-              withControls={false}
-              getEmblaApi={setEmblaFsApi}
-              initialSlide={activeIndex}
-              className="h-full w-full"
-              styles={{
-                viewport: { height: '100%' },
-                container: { height: '100%' },
-              }}
-            >
-              {images.map((image, index) => (
-                <Carousel.Slide key={index} className="flex items-center justify-center">
-                  <div className="w-full h-full flex items-center justify-center">
-                    <img
-                      src={image.preview || image.original}
-                      alt={`${name} ${index + 1}`}
-                      className="max-w-full max-h-full object-contain"
-                      onClick={() => setShowAllImages(false)}
-                    />
-                  </div>
-                </Carousel.Slide>
-              ))}
-            </Carousel>
-
-            {images.length > 1 && (
-              <div className="absolute inset-y-0 left-2 flex items-center z-50">
-                <ActionIcon
-                  variant="filled"
-                  color="dark"
-                  size="lg"
-                  onClick={() => scrollPrev(emblaFsApi)}
-                  aria-label="Previous image"
-                >
-                  <ChevronLeft size={24} />
-                </ActionIcon>
-              </div>
-            )}
-            {images.length > 1 && (
-              <div className="absolute inset-y-0 right-2 flex items-center z-50">
-                <ActionIcon
-                  variant="filled"
-                  color="dark"
-                  size="lg"
-                  onClick={() => scrollNext(emblaFsApi)}
-                  aria-label="Next image"
-                >
-                  <ChevronRight size={24} />
-                </ActionIcon>
-              </div>
-            )}
-
-            <ActionIcon
-              variant="subtle"
-              color="gray"
-              size="lg"
-              c="white"
-              className="absolute top-4 right-4"
-              onClick={() => setShowAllImages(false)}
-              aria-label="Close"
-            >
-              <X size={24} />
-            </ActionIcon>
-          </div>
+      {/* Rental calendar — only for rental items and logged-in users */}
+      {isRental && !!user && (
+        <div className="mt-10" id="booking" ref={rentalCalendarRef}>
+          <RentalCalendar
+            itemUuid={itemUuid}
+            onDateRangeSelect={handleDateRangeSelect}
+            selectedStart={selectedStartDate}
+            selectedEnd={selectedEndDate}
+            onBookNow={handleBookNowFromCalendar}
+          />
         </div>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

Refactors the `ItemDetail` view and reworks the image gallery into a dedicated, nicer carousel component.

### New `ItemImageCarousel` component
Extracted all gallery logic out of `ItemDetail` into `frontend/src/components/items/ItemImageCarousel.tsx`:

- Hover-revealed circular edge arrows overlaid on the image (always visible on touch)
- Image counter badge (`2 / 5`) inline and in the lightbox
- Animated dot indicators — the active dot stretches into a pill
- Expand button to open the full-screen lightbox
- Larger, responsive images (`h-64` → `lg:h-96`), `object-cover`, rounded, with lazy-loading for non-first images
- Scoped keyboard navigation (arrows drive the visible carousel, Escape closes the lightbox) with inline/lightbox sync via `useDisclosure`

### `ItemDetail` cleanup
- Removed all embla/fullscreen state and effects (now owned by the carousel)
- Hoisted booking action label, disabled logic, and the dialog out of nested inline IIFEs
- Simplified property rendering with a small `formatPropertyValue` helper and pre-sorted entries
- Consolidated loading / error / not-found branches (now uses the existing `itemDetail.notFound` key)
- Tightened spacing and grid layout throughout

### i18n
- Added carousel accessibility labels (`previousImage`, `nextImage`, `openImage`, `closeViewer`, `goToImage`) in English and German

## Testing
- `tsc` — no new type errors (remaining ones are pre-existing on base)
- `eslint` — clean on changed files
- `vite build` — succeeds

https://claude.ai/code/session_01K7wawjmyo2xhC67A9ZRz7C

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7wawjmyo2xhC67A9ZRz7C)_