### PR TITLE
feat(search): faceted header search bar with owner, collection, category and availability filters

### DIFF
--- a/backend/bubble/items/api/filters.py
+++ b/backend/bubble/items/api/filters.py
@@ -28,6 +28,7 @@ class ItemFilter(django_filters.FilterSet):
     - sales_type: multiple choice filter for sales type values
     - min_price / max_price: numeric range for price
     - user: user id for owner filtering
+    - collection: collection id; restrict to items in the given collection
     - search: substring match on name or description (case-insensitive)
     - created_after / created_before: ISO8601 datetime filtering
     """
@@ -55,6 +56,9 @@ class ItemFilter(django_filters.FilterSet):
     # Unified price range filters
     min_price = django_filters.NumberFilter(field_name="price", lookup_expr="gte")
     max_price = django_filters.NumberFilter(field_name="price", lookup_expr="lte")
+
+    # Restrict to items contained in a given collection
+    collection = django_filters.UUIDFilter(field_name="collections__id")
 
     # Use built-in search filter
     search = django_filters.CharFilter(method="filter_search")

--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -13,6 +13,7 @@ from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from guardian.shortcuts import (
     assign_perm,
     get_groups_with_perms,
@@ -102,6 +103,22 @@ class ItemBaseViewSet(viewsets.GenericViewSet):
         return ItemSerializer
 
 
+class ItemOwnerSerializer(serializers.Serializer):
+    """Read-only serializer describing a user who owns visible published items."""
+
+    id = serializers.CharField()
+    username = serializers.CharField()
+    name = serializers.CharField(allow_blank=True)
+    item_count = serializers.IntegerField()
+
+
+class CategoryFacetSerializer(serializers.Serializer):
+    """Read-only serializer describing a category and its visible item count."""
+
+    category = serializers.CharField()
+    count = serializers.IntegerField()
+
+
 class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
     """
     ViewSet for retrieving published items.
@@ -147,6 +164,51 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
             # PRIVATE: owner + co-owners get view_item in Item.save()
             | models.Q(visibility=VisibilityType.PRIVATE, pk__in=explicitly_visible)
         )
+
+    @extend_schema(responses=ItemOwnerSerializer(many=True))
+    @action(detail=False, methods=["get"])
+    def owners(self, request):
+        """List distinct owners of items visible to the requesting user.
+
+        Powers the "owner" facet of the search bar: every user who has at
+        least one shared (published and visible) item, with the number of
+        such items. Results are ordered alphabetically by username.
+        """
+        owners = (
+            self.get_queryset()
+            .values("user__id", "user__username", "user__name")
+            .annotate(item_count=models.Count("id"))
+            .order_by("user__username")
+        )
+        data = [
+            {
+                "id": str(owner["user__id"]),
+                "username": owner["user__username"],
+                "name": owner["user__name"] or "",
+                "item_count": owner["item_count"],
+            }
+            for owner in owners
+        ]
+        return Response(ItemOwnerSerializer(data, many=True).data)
+
+    @extend_schema(responses=CategoryFacetSerializer(many=True))
+    @action(detail=False, methods=["get"])
+    def categories(self, request):
+        """List categories present among items visible to the requesting user.
+
+        Powers the "category" facet of the search bar: each category that has
+        at least one shared (published and visible) item, together with the
+        number of such items. Results are ordered alphabetically by category.
+        """
+        rows = (
+            self.get_queryset()
+            .exclude(category="")
+            .values("category")
+            .annotate(count=models.Count("id"))
+            .order_by("category")
+        )
+        data = [{"category": row["category"], "count": row["count"]} for row in rows]
+        return Response(CategoryFacetSerializer(data, many=True).data)
 
 
 class ItemViewSet(viewsets.ModelViewSet, ItemBaseViewSet):

--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -32,6 +32,7 @@ from rest_framework.permissions import (
 )
 from rest_framework.response import Response
 
+from bubble.collections.models import Collection
 from bubble.core.storage import absolute_media_url
 from bubble.federation.models import RemoteItem
 from bubble.items.ai.image_analyze import analyze_image
@@ -41,7 +42,7 @@ from bubble.items.api.serializers import (
     ItemListSerializer,
     ItemSerializer,
 )
-from bubble.items.models import Image, Item, VisibilityType
+from bubble.items.models import Image, Item, ItemStatus, VisibilityType
 
 from .filters import ItemFilter
 
@@ -103,20 +104,53 @@ class ItemBaseViewSet(viewsets.GenericViewSet):
         return ItemSerializer
 
 
-class ItemOwnerSerializer(serializers.Serializer):
-    """Read-only serializer describing a user who owns visible published items."""
+# Availability facet value → the item statuses it maps to.
+AVAILABILITY_STATUSES = {
+    "available": [ItemStatus.AVAILABLE, ItemStatus.RESERVED],
+    "rented": [ItemStatus.RENTED],
+    "sold": [ItemStatus.SOLD],
+}
+
+
+class CategoryFacetSerializer(serializers.Serializer):
+    """A category and the number of matching visible items."""
+
+    category = serializers.CharField()
+    count = serializers.IntegerField()
+
+
+class CollectionFacetSerializer(serializers.Serializer):
+    """A collection and the number of matching visible items it contains."""
+
+    id = serializers.CharField()
+    name = serializers.CharField()
+    owner = serializers.CharField()
+    count = serializers.IntegerField()
+
+
+class OwnerFacetSerializer(serializers.Serializer):
+    """An owner and the number of their matching visible items."""
 
     id = serializers.CharField()
     username = serializers.CharField()
     name = serializers.CharField(allow_blank=True)
-    item_count = serializers.IntegerField()
-
-
-class CategoryFacetSerializer(serializers.Serializer):
-    """Read-only serializer describing a category and its visible item count."""
-
-    category = serializers.CharField()
     count = serializers.IntegerField()
+
+
+class AvailabilityFacetSerializer(serializers.Serializer):
+    """An availability value and the number of matching visible items."""
+
+    value = serializers.CharField()
+    count = serializers.IntegerField()
+
+
+class SearchFacetsSerializer(serializers.Serializer):
+    """The full set of search facets, each excluding its own active filter."""
+
+    categories = CategoryFacetSerializer(many=True)
+    collections = CollectionFacetSerializer(many=True)
+    availability = AvailabilityFacetSerializer(many=True)
+    owners = OwnerFacetSerializer(many=True)
 
 
 class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
@@ -165,50 +199,115 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
             | models.Q(visibility=VisibilityType.PRIVATE, pk__in=explicitly_visible)
         )
 
-    @extend_schema(responses=ItemOwnerSerializer(many=True))
-    @action(detail=False, methods=["get"])
-    def owners(self, request):
-        """List distinct owners of items visible to the requesting user.
+    @staticmethod
+    def _as_uuid(value):
+        """Return value if it is a valid UUID string, otherwise None."""
+        if not value:
+            return None
+        try:
+            _uuid.UUID(str(value))
+        except (ValueError, TypeError, AttributeError):
+            return None
+        return value
 
-        Powers the "owner" facet of the search bar: every user who has at
-        least one shared (published and visible) item, with the number of
-        such items. Results are ordered alphabetically by username.
+    @extend_schema(responses=SearchFacetsSerializer)
+    @action(detail=False, methods=["get"])
+    def facets(self, request):
+        """Return the search facets, cross-filtered by the active selection.
+
+        Powers the header search popup. Each facet (category, collection,
+        availability, owner) is computed over the visible items narrowed by
+        every *other* active filter, but never by the facet's own dimension —
+        so picking a collection updates the categories/owners/availability on
+        offer (and their counts) while still letting you switch collection.
         """
-        owners = (
-            self.get_queryset()
-            .values("user__id", "user__username", "user__name")
-            .annotate(item_count=models.Count("id"))
-            .order_by("user__username")
+        category = request.query_params.get("category") or None
+        collection = self._as_uuid(request.query_params.get("collection"))
+        owner = self._as_uuid(
+            request.query_params.get("owner") or request.query_params.get("user")
         )
-        data = [
-            {
-                "id": str(owner["user__id"]),
-                "username": owner["user__username"],
-                "name": owner["user__name"] or "",
-                "item_count": owner["item_count"],
-            }
-            for owner in owners
-        ]
-        return Response(ItemOwnerSerializer(data, many=True).data)
+        availability = request.query_params.get("availability") or None
+        search = (request.query_params.get("search") or "").strip()
 
-    @extend_schema(responses=CategoryFacetSerializer(many=True))
-    @action(detail=False, methods=["get"])
-    def categories(self, request):
-        """List categories present among items visible to the requesting user.
+        base = self.get_queryset()
 
-        Powers the "category" facet of the search bar: each category that has
-        at least one shared (published and visible) item, together with the
-        number of such items. Results are ordered alphabetically by category.
-        """
-        rows = (
-            self.get_queryset()
+        def narrowed(exclude: str):
+            """Visible items filtered by every active filter except ``exclude``."""
+            qs = base
+            if category and exclude != "category":
+                qs = qs.filter(category=category)
+            if collection and exclude != "collection":
+                qs = qs.filter(collections__id=collection)
+            if owner and exclude != "owner":
+                qs = qs.filter(user_id=owner)
+            if availability and exclude != "availability":
+                qs = qs.filter(status__in=AVAILABILITY_STATUSES.get(availability, []))
+            if search:
+                qs = qs.filter(
+                    models.Q(name__icontains=search)
+                    | models.Q(description__icontains=search)
+                )
+            return qs
+
+        count = models.Count("id", distinct=True)
+
+        categories = [
+            {"category": row["category"], "count": row["count"]}
+            for row in narrowed("category")
             .exclude(category="")
             .values("category")
-            .annotate(count=models.Count("id"))
+            .annotate(count=count)
             .order_by("category")
-        )
-        data = [{"category": row["category"], "count": row["count"]} for row in rows]
-        return Response(CategoryFacetSerializer(data, many=True).data)
+        ]
+
+        viewable_collections = Collection.objects.get_for_user(
+            request.user
+        ).values_list("id", flat=True)
+        collections = [
+            {
+                "id": str(row["collections__id"]),
+                "name": row["collections__name"],
+                "owner": row["collections__owner__username"],
+                "count": row["count"],
+            }
+            for row in narrowed("collection")
+            .filter(collections__id__in=viewable_collections)
+            .values(
+                "collections__id",
+                "collections__name",
+                "collections__owner__username",
+            )
+            .annotate(count=count)
+            .order_by("collections__name")
+        ]
+
+        owners = [
+            {
+                "id": str(row["user__id"]),
+                "username": row["user__username"],
+                "name": row["user__name"] or "",
+                "count": row["count"],
+            }
+            for row in narrowed("owner")
+            .values("user__id", "user__username", "user__name")
+            .annotate(count=count)
+            .order_by("user__username")
+        ]
+
+        availability_base = narrowed("availability")
+        availability_facets = []
+        for value, statuses in AVAILABILITY_STATUSES.items():
+            value_count = availability_base.filter(status__in=statuses).count()
+            if value_count:
+                availability_facets.append({"value": value, "count": value_count})
+
+        data = {
+            "categories": categories,
+            "collections": collections,
+            "availability": availability_facets,
+            "owners": owners,
+        }
+        return Response(SearchFacetsSerializer(data).data)
 
 
 class ItemViewSet(viewsets.ModelViewSet, ItemBaseViewSet):

--- a/backend/bubble/items/tests/tests.py
+++ b/backend/bubble/items/tests/tests.py
@@ -1247,6 +1247,9 @@ class PublicItemFacetTestCase(TestCase):
         self.bob = ItemOwnerUserFactory(
             username="bob", email="bob@example.com", password=TEST_PASSWORD
         )
+        # Collections are only visible to authenticated users, so the facet
+        # tests run as alice (who owns the collection created below).
+        self.client.force_authenticate(user=self.alice)
 
         # alice: an available tool and an available book.
         self.alice_tool = Item.objects.create(

--- a/backend/bubble/items/tests/tests.py
+++ b/backend/bubble/items/tests/tests.py
@@ -1234,10 +1234,10 @@ class ItemSerializerValidationTestCase(TestCase):
 
 
 class PublicItemFacetTestCase(TestCase):
-    """Tests for the owner / category facet endpoints and collection filter."""
+    """Tests for the cross-filtering search facets and the collection filter."""
 
     def setUp(self):
-        """Create published items owned by two users across categories."""
+        """Create published items spanning owners, categories and availability."""
         config.REQUIRE_LOGIN = False
         self.client = APIClient()
 
@@ -1248,7 +1248,7 @@ class PublicItemFacetTestCase(TestCase):
             username="bob", email="bob@example.com", password=TEST_PASSWORD
         )
 
-        # Two published tools owned by alice.
+        # alice: an available tool and an available book.
         self.alice_tool = Item.objects.create(
             name="Alice Hammer",
             user=self.alice,
@@ -1265,16 +1265,15 @@ class PublicItemFacetTestCase(TestCase):
             visibility=VisibilityType.PUBLIC,
             category="books",
         )
-        # One published tool owned by bob.
+        # bob: a sold tool, plus a draft that must never count.
         self.bob_tool = Item.objects.create(
             name="Bob Wrench",
             user=self.bob,
             sales_type=SalesType.SELL,
-            status=ItemStatus.AVAILABLE,
+            status=ItemStatus.SOLD,
             visibility=VisibilityType.PUBLIC,
             category="tools",
         )
-        # A draft item should not contribute to any facet.
         self.bob_draft = Item.objects.create(
             name="Bob Draft Saw",
             user=self.bob,
@@ -1284,36 +1283,68 @@ class PublicItemFacetTestCase(TestCase):
             category="tools",
         )
 
+        # A collection owned by alice holding both of her items.
+        self.collection = Collection.objects.create(
+            name="Favorite Tools", owner=self.alice
+        )
+        CollectionItem.objects.create(
+            collection=self.collection, item=self.alice_tool, added_by=self.alice
+        )
+        CollectionItem.objects.create(
+            collection=self.collection, item=self.alice_book, added_by=self.alice
+        )
+
     def tearDown(self):
         """Restore default constance config."""
         config.REQUIRE_LOGIN = True
 
-    def test_owners_endpoint_lists_owners_with_counts(self):
-        """The owners facet returns each owner of published items with a count."""
-        url = reverse("api:public-item-owners")
-        response = self.client.get(url)
-
+    def _facets(self, **params):
+        """GET the facets endpoint and return its parsed JSON body."""
+        url = reverse("api:public-item-facets")
+        response = self.client.get(url, params)
         assert response.status_code == status.HTTP_200_OK
-        by_username = {row["username"]: row for row in response.json()}
+        return response.json()
 
-        # alice has two published items, bob has one (his draft is excluded).
-        counts = {username: row["item_count"] for username, row in by_username.items()}
-        assert counts == {"alice": 2, "bob": 1}
-        assert by_username["alice"]["id"] == str(self.alice.pk)
+    @staticmethod
+    def _by(data, key, value="count"):
+        """Collapse a facet list into a ``{key: count}`` mapping."""
+        return {row[key]: row[value] for row in data}
 
-    def test_categories_endpoint_lists_categories_with_counts(self):
-        """The category facet returns each category with its published count."""
-        url = reverse("api:public-item-categories")
-        response = self.client.get(url)
+    def test_facets_unfiltered(self):
+        """With no selection, every facet covers all visible (published) items."""
+        data = self._facets()
 
-        assert response.status_code == status.HTTP_200_OK
-        counts = {row["category"]: row["count"] for row in response.json()}
+        assert self._by(data["categories"], "category") == {"tools": 2, "books": 1}
+        assert self._by(data["owners"], "username") == {"alice": 2, "bob": 1}
+        # available: both alice items; sold: bob's tool; drafts excluded.
+        assert self._by(data["availability"], "value") == {"available": 2, "sold": 1}
+        assert self._by(data["collections"], "name") == {"Favorite Tools": 2}
+        assert data["collections"][0]["owner"] == "alice"
 
-        # tools: alice_tool + bob_tool (bob_draft excluded), books: alice_book.
-        assert counts == {"tools": 2, "books": 1}
+    def test_facets_cross_filter_by_collection(self):
+        """Selecting a collection narrows the other facets to its items."""
+        data = self._facets(collection=str(self.collection.pk))
 
-    def test_owners_endpoint_excludes_unpublished_only_owners(self):
-        """A user with only draft items must not appear in the owners facet."""
+        # Only alice's two items are in the collection.
+        assert self._by(data["categories"], "category") == {"tools": 1, "books": 1}
+        assert self._by(data["owners"], "username") == {"alice": 2}
+        assert self._by(data["availability"], "value") == {"available": 2}
+        # The collection facet excludes its own dimension, so it is unchanged.
+        assert self._by(data["collections"], "name") == {"Favorite Tools": 2}
+
+    def test_facets_cross_filter_by_category(self):
+        """Selecting a category narrows owners, availability and collections."""
+        data = self._facets(category="tools")
+
+        # Category facet keeps every category so the choice can be changed.
+        assert self._by(data["categories"], "category") == {"tools": 2, "books": 1}
+        assert self._by(data["owners"], "username") == {"alice": 1, "bob": 1}
+        assert self._by(data["availability"], "value") == {"available": 1, "sold": 1}
+        # Favorite Tools only contributes its single tool once books are excluded.
+        assert self._by(data["collections"], "name") == {"Favorite Tools": 1}
+
+    def test_facets_owners_exclude_unpublished_only_owners(self):
+        """A user with only draft items never appears in the owners facet."""
         carol = ItemOwnerUserFactory(
             username="carol", email="carol@example.com", password=TEST_PASSWORD
         )
@@ -1325,22 +1356,16 @@ class PublicItemFacetTestCase(TestCase):
             visibility=VisibilityType.PUBLIC,
             category="tools",
         )
-        url = reverse("api:public-item-owners")
-        response = self.client.get(url)
+        data = self._facets()
 
-        usernames = {row["username"] for row in response.json()}
+        usernames = {row["username"] for row in data["owners"]}
         assert "carol" not in usernames
 
     def test_collection_filter_restricts_to_collection_items(self):
-        """The collection filter returns only items contained in the collection."""
-        collection = Collection.objects.create(name="Alice Picks", owner=self.alice)
-        CollectionItem.objects.create(
-            collection=collection, item=self.alice_tool, added_by=self.alice
-        )
-
-        url = reverse("api:public-item-list") + f"?collection={collection.pk}"
+        """The item-list collection filter returns only the collection's items."""
+        url = reverse("api:public-item-list") + f"?collection={self.collection.pk}"
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         names = {item["name"] for item in response.json()["results"]}
-        assert names == {self.alice_tool.name}
+        assert names == {self.alice_tool.name, self.alice_book.name}

--- a/backend/bubble/items/tests/tests.py
+++ b/backend/bubble/items/tests/tests.py
@@ -14,6 +14,7 @@ from PIL import Image as PILImage
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from bubble.collections.models import Collection, CollectionItem
 from bubble.core.permissions_config import DefaultGroup
 from bubble.items.ai.image_analyze import ItemImageResult
 from bubble.items.models import Image, Item, ItemStatus, SalesType, VisibilityType
@@ -1230,3 +1231,116 @@ class ItemSerializerValidationTestCase(TestCase):
         assert response.status_code == status.HTTP_200_OK
         item.refresh_from_db()
         assert item.price.amount == Decimal("25.00")
+
+
+class PublicItemFacetTestCase(TestCase):
+    """Tests for the owner / category facet endpoints and collection filter."""
+
+    def setUp(self):
+        """Create published items owned by two users across categories."""
+        config.REQUIRE_LOGIN = False
+        self.client = APIClient()
+
+        self.alice = ItemOwnerUserFactory(
+            username="alice", email="alice@example.com", password=TEST_PASSWORD
+        )
+        self.bob = ItemOwnerUserFactory(
+            username="bob", email="bob@example.com", password=TEST_PASSWORD
+        )
+
+        # Two published tools owned by alice.
+        self.alice_tool = Item.objects.create(
+            name="Alice Hammer",
+            user=self.alice,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+        self.alice_book = Item.objects.create(
+            name="Alice Novel",
+            user=self.alice,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="books",
+        )
+        # One published tool owned by bob.
+        self.bob_tool = Item.objects.create(
+            name="Bob Wrench",
+            user=self.bob,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+        # A draft item should not contribute to any facet.
+        self.bob_draft = Item.objects.create(
+            name="Bob Draft Saw",
+            user=self.bob,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.DRAFT,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+
+    def tearDown(self):
+        """Restore default constance config."""
+        config.REQUIRE_LOGIN = True
+
+    def test_owners_endpoint_lists_owners_with_counts(self):
+        """The owners facet returns each owner of published items with a count."""
+        url = reverse("api:public-item-owners")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        by_username = {row["username"]: row for row in response.json()}
+
+        # alice has two published items, bob has one (his draft is excluded).
+        counts = {username: row["item_count"] for username, row in by_username.items()}
+        assert counts == {"alice": 2, "bob": 1}
+        assert by_username["alice"]["id"] == str(self.alice.pk)
+
+    def test_categories_endpoint_lists_categories_with_counts(self):
+        """The category facet returns each category with its published count."""
+        url = reverse("api:public-item-categories")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        counts = {row["category"]: row["count"] for row in response.json()}
+
+        # tools: alice_tool + bob_tool (bob_draft excluded), books: alice_book.
+        assert counts == {"tools": 2, "books": 1}
+
+    def test_owners_endpoint_excludes_unpublished_only_owners(self):
+        """A user with only draft items must not appear in the owners facet."""
+        carol = ItemOwnerUserFactory(
+            username="carol", email="carol@example.com", password=TEST_PASSWORD
+        )
+        Item.objects.create(
+            name="Carol Draft",
+            user=carol,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.DRAFT,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+        url = reverse("api:public-item-owners")
+        response = self.client.get(url)
+
+        usernames = {row["username"] for row in response.json()}
+        assert "carol" not in usernames
+
+    def test_collection_filter_restricts_to_collection_items(self):
+        """The collection filter returns only items contained in the collection."""
+        collection = Collection.objects.create(name="Alice Picks", owner=self.alice)
+        CollectionItem.objects.create(
+            collection=collection, item=self.alice_tool, added_by=self.alice
+        )
+
+        url = reverse("api:public-item-list") + f"?collection={collection.pk}"
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        names = {item["name"] for item in response.json()["results"]}
+        assert names == {self.alice_tool.name}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -47,7 +47,7 @@ export const Header = () => {
               </div>
             </NavLink>
             <div className="flex-1 max-w-lg">
-              <SearchBar showOwner={false} />
+              <SearchBar loggedIn={false} />
             </div>
 
             <Button
@@ -81,7 +81,7 @@ export const Header = () => {
 
           {/* Search Bar */}
           <div className="flex-1 max-w-lg">
-            <SearchBar showOwner />
+            <SearchBar loggedIn />
           </div>
 
           {/* Actions */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
-import { ActionIcon, Avatar, Button, Indicator, Menu, TextInput } from '@mantine/core';
+import { ActionIcon, Avatar, Button, Indicator, Menu } from '@mantine/core';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useMessages';
-import * as Sentry from '@sentry/react';
+import { SearchBar } from '@/components/layout/SearchBar';
 
 import { cn } from '@/lib/utils';
 import {
@@ -13,17 +13,14 @@ import {
   LogIn,
   LogOut,
   Plus,
-  Search,
   User,
 } from 'lucide-react';
-import { SubmitEvent, useEffect, useRef, useState } from 'react';
-import { NavLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 export const Header = () => {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const [searchParams, setSearchParams] = useSearchParams();
   const { data: unreadMessages } = useUnreadMessages();
 
   const { t } = useLanguage();
@@ -33,36 +30,6 @@ export const Header = () => {
   const handleSignOut = async () => {
     await signOut();
     navigate('/');
-  };
-
-  const searchTerm = searchParams.get('search') || '';
-  const [inputValue, setInputValue] = useState(searchTerm);
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleSearchChange = (term: string) => {
-    setInputValue(term);
-
-    if (debounceTimer.current) clearTimeout(debounceTimer.current);
-
-    debounceTimer.current = setTimeout(() => {
-      const next = new URLSearchParams(searchParams);
-      if (term.length > 0) {
-        next.set('search', term);
-      } else {
-        next.delete('search');
-      }
-      setSearchParams(next, { replace: true });
-    }, 300);
-  };
-
-  // Keep input in sync if the URL param changes externally (e.g. browser back/forward)
-  useEffect(() => {
-    setInputValue(searchTerm);
-  }, [searchTerm]);
-
-  const handleSubmit = (event: SubmitEvent) => {
-    event.preventDefault();
-    setSearchParams(searchParams, { replace: false });
   };
 
   if (!user) {
@@ -79,17 +46,9 @@ export const Header = () => {
                 <p className="text-xs text-muted-foreground">Community Network</p>
               </div>
             </NavLink>
-            <form className="flex-1 max-w-lg" onSubmit={handleSubmit}>
-              <div className="relative">
-                <TextInput
-                  placeholder={t('header.search')}
-                  leftSection={<Search size={16} aria-hidden="true" />}
-                  className="shadow-soft focus-within:shadow-medium transition-shadow"
-                  value={inputValue}
-                  onChange={e => handleSearchChange(e.target.value)}
-                />
-              </div>
-            </form>
+            <div className="flex-1 max-w-lg">
+              <SearchBar showOwner={false} />
+            </div>
 
             <Button
               variant="default"
@@ -121,17 +80,9 @@ export const Header = () => {
           </NavLink>
 
           {/* Search Bar */}
-          <form className="flex-1 max-w-lg" onSubmit={handleSubmit}>
-            <div className="relative">
-              <TextInput
-                placeholder={t('header.search')}
-                leftSection={<Search size={16} aria-hidden="true" />}
-                className="shadow-soft focus-within:shadow-medium transition-shadow"
-                value={inputValue}
-                onChange={e => handleSearchChange(e.target.value)}
-              />
-            </div>
-          </form>
+          <div className="flex-1 max-w-lg">
+            <SearchBar showOwner />
+          </div>
 
           {/* Actions */}
           <div className="flex items-center gap-2">

--- a/frontend/src/components/layout/SearchBar.tsx
+++ b/frontend/src/components/layout/SearchBar.tsx
@@ -1,0 +1,379 @@
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAllCollections } from '@/hooks/useCollections';
+import { useCategoryFacets, useItemOwners } from '@/hooks/useSearchFacets';
+import { categoryTranslationKeys, getCategoryIcon } from '@/lib/categoryIcons';
+import { cn } from '@/lib/utils';
+import {
+  Button,
+  Loader,
+  Pill,
+  PillsInput,
+  Popover,
+  ScrollArea,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from '@mantine/core';
+import { BookMarked, Check, CircleDot, Search, Tag, User } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Types & constants
+// ---------------------------------------------------------------------------
+
+type Facet = 'owner' | 'collection' | 'category' | 'availability';
+
+const AVAILABILITY_OPTIONS = ['available', 'rented', 'sold'] as const;
+
+const FACET_ICONS: Record<Facet, LucideIcon> = {
+  owner: User,
+  collection: BookMarked,
+  category: Tag,
+  availability: CircleDot,
+};
+
+// The browse/results page that the header search drives.
+const BROWSE_PATH = '/';
+
+interface SearchBarProps {
+  /** Whether the owner facet is offered (logged-in users only). */
+  showOwner: boolean;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Filters only have meaning on the browse page; elsewhere the bar acts as an
+  // entry point that navigates to the browse page once a filter or term is set.
+  const onBrowse = location.pathname === BROWSE_PATH;
+  const currentParams = useMemo(
+    () => new URLSearchParams(onBrowse ? location.search : ''),
+    [onBrowse, location.search],
+  );
+
+  const ownerId = currentParams.get('owner') || undefined;
+  const collectionId = currentParams.get('collection') || undefined;
+  const categoryValue = currentParams.get('category') || undefined;
+  const availabilityValue = currentParams.get('availability') || undefined;
+  const searchValue = currentParams.get('search') ?? '';
+
+  const [opened, setOpened] = useState(false);
+  const facets: Facet[] = useMemo(
+    () =>
+      showOwner
+        ? ['owner', 'collection', 'category', 'availability']
+        : ['collection', 'category', 'availability'],
+    [showOwner],
+  );
+  const [activeFacet, setActiveFacet] = useState<Facet>(facets[0]);
+  const [facetQuery, setFacetQuery] = useState('');
+
+  // Free-text item search (mirrors the URL `search` param, debounced).
+  const [inputValue, setInputValue] = useState(searchValue);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Adopt the URL value whenever it changes externally (back/forward, chips),
+  // without an effect — React's "adjusting state when a prop changes" pattern.
+  const [lastSyncedSearch, setLastSyncedSearch] = useState(searchValue);
+  if (lastSyncedSearch !== searchValue) {
+    setLastSyncedSearch(searchValue);
+    setInputValue(searchValue);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data for the facet lists
+  // ---------------------------------------------------------------------------
+
+  const ownersQuery = useItemOwners({ enabled: (opened && showOwner) || !!ownerId });
+  const collectionsQuery = useAllCollections({ enabled: opened || !!collectionId });
+  const categoriesQuery = useCategoryFacets({ enabled: opened });
+
+  const resolveOwnerLabel = (id: string) => {
+    const owner = ownersQuery.data?.find(o => o.id === id);
+    return owner ? owner.name || owner.username : '…';
+  };
+  const resolveCollectionLabel = (id: string) => {
+    const collection = collectionsQuery.data?.find(c => String(c.id) === id);
+    return collection ? `${collection.name} (${collection.owner})` : '…';
+  };
+
+  // ---------------------------------------------------------------------------
+  // URL helpers
+  // ---------------------------------------------------------------------------
+
+  const applyParams = useCallback(
+    (mutate: (params: URLSearchParams) => void, opts?: { replace?: boolean }) => {
+      const params = new URLSearchParams(onBrowse ? location.search : '');
+      mutate(params);
+      params.delete('page');
+      const search = params.toString();
+      navigate(
+        { pathname: BROWSE_PATH, search: search ? `?${search}` : '' },
+        { replace: !!opts?.replace && onBrowse },
+      );
+    },
+    [navigate, onBrowse, location.search],
+  );
+
+  const handleSearchChange = (term: string) => {
+    setInputValue(term);
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      applyParams(
+        params => {
+          if (term) params.set('search', term);
+          else params.delete('search');
+        },
+        { replace: true },
+      );
+    }, 300);
+  };
+
+  const selectFacet = (key: Facet, value: string) => {
+    applyParams(params => params.set(key, value));
+    setFacetQuery('');
+    setOpened(false);
+  };
+
+  const clearFacet = (key: string) => applyParams(params => params.delete(key), { replace: true });
+
+  // ---------------------------------------------------------------------------
+  // Active filter chips
+  // ---------------------------------------------------------------------------
+
+  const chips: { key: string; label: string }[] = [];
+  if (ownerId) chips.push({ key: 'owner', label: resolveOwnerLabel(ownerId) });
+  if (collectionId) chips.push({ key: 'collection', label: resolveCollectionLabel(collectionId) });
+  if (categoryValue && categoryValue !== 'all')
+    chips.push({
+      key: 'category',
+      label: t(categoryTranslationKeys[categoryValue] ?? categoryValue),
+    });
+  if (availabilityValue)
+    chips.push({ key: 'availability', label: t(`search.availability.${availabilityValue}`) });
+
+  // ---------------------------------------------------------------------------
+  // Facet panel rendering
+  // ---------------------------------------------------------------------------
+
+  const facetSearchPlaceholder: Record<Facet, string> = {
+    owner: t('search.searchOwners'),
+    collection: t('search.searchCollections'),
+    category: t('search.searchCategories'),
+    availability: '',
+  };
+
+  const renderRow = (
+    key: string,
+    {
+      icon,
+      label,
+      meta,
+      active,
+      onSelect,
+    }: {
+      icon?: React.ReactNode;
+      label: string;
+      meta?: string;
+      active: boolean;
+      onSelect: () => void;
+    },
+  ) => (
+    <UnstyledButton
+      key={key}
+      onClick={onSelect}
+      className={cn(
+        'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-[var(--mantine-color-default-hover)]',
+        active && 'bg-[var(--mantine-color-default-hover)]',
+      )}
+    >
+      {icon}
+      <span className="flex-1 truncate text-sm">{label}</span>
+      {meta && (
+        <Text span size="xs" c="dimmed" className="shrink-0">
+          {meta}
+        </Text>
+      )}
+      {active && <Check size={14} className="shrink-0 text-[var(--mantine-color-green-6)]" />}
+    </UnstyledButton>
+  );
+
+  const renderPanel = () => {
+    const query = facetQuery.trim().toLowerCase();
+
+    if (activeFacet === 'availability') {
+      return (
+        <div className="flex flex-col">
+          {AVAILABILITY_OPTIONS.map(value =>
+            renderRow(value, {
+              icon: <CircleDot size={16} className="text-muted-foreground" />,
+              label: t(`search.availability.${value}`),
+              active: availabilityValue === value,
+              onSelect: () => selectFacet('availability', value),
+            }),
+          )}
+        </div>
+      );
+    }
+
+    const loading =
+      activeFacet === 'owner'
+        ? ownersQuery.isLoading
+        : activeFacet === 'collection'
+          ? collectionsQuery.isLoading
+          : categoriesQuery.isLoading;
+
+    let rows: React.ReactNode[] = [];
+    if (activeFacet === 'owner') {
+      rows = (ownersQuery.data ?? [])
+        .filter(
+          o =>
+            !query ||
+            o.username.toLowerCase().includes(query) ||
+            o.name.toLowerCase().includes(query),
+        )
+        .map(o =>
+          renderRow(o.id, {
+            icon: <User size={16} className="text-muted-foreground" />,
+            label: o.name || o.username,
+            meta: String(o.item_count),
+            active: ownerId === o.id,
+            onSelect: () => selectFacet('owner', o.id),
+          }),
+        );
+    } else if (activeFacet === 'collection') {
+      rows = (collectionsQuery.data ?? [])
+        .filter(c => !query || c.name.toLowerCase().includes(query))
+        .map(c =>
+          renderRow(String(c.id), {
+            icon: <BookMarked size={16} className="text-muted-foreground" />,
+            label: c.name,
+            meta: `(${c.owner})`,
+            active: collectionId === String(c.id),
+            onSelect: () => selectFacet('collection', String(c.id)),
+          }),
+        );
+    } else {
+      rows = (categoriesQuery.data ?? [])
+        .map(facet => {
+          const label = t(categoryTranslationKeys[facet.category] ?? facet.category);
+          return { facet, label };
+        })
+        .filter(({ label }) => !query || label.toLowerCase().includes(query))
+        .map(({ facet, label }) => {
+          const Icon = getCategoryIcon(facet.category);
+          return renderRow(facet.category, {
+            icon: <Icon size={16} className="text-muted-foreground" />,
+            label,
+            meta: `(${facet.count})`,
+            active: categoryValue === facet.category,
+            onSelect: () => selectFacet('category', facet.category),
+          });
+        });
+    }
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <TextInput
+          size="xs"
+          value={facetQuery}
+          placeholder={facetSearchPlaceholder[activeFacet]}
+          leftSection={<Search size={14} aria-hidden="true" />}
+          onChange={e => setFacetQuery(e.currentTarget.value)}
+        />
+        {loading ? (
+          <div className="flex justify-center py-4">
+            <Loader size="sm" />
+          </div>
+        ) : rows.length > 0 ? (
+          <ScrollArea.Autosize mah={240} type="hover">
+            <div className="flex flex-col pr-1">{rows}</div>
+          </ScrollArea.Autosize>
+        ) : (
+          <Text size="sm" c="dimmed" className="py-3 text-center">
+            {t('search.noResults')}
+          </Text>
+        )}
+      </div>
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      position="bottom-start"
+      width="target"
+      shadow="md"
+      trapFocus={false}
+      withinPortal
+    >
+      <Popover.Target>
+        <PillsInput
+          size="sm"
+          onClick={() => setOpened(true)}
+          leftSection={<Search size={16} aria-hidden="true" />}
+          className={cn('shadow-soft focus-within:shadow-medium transition-shadow', className)}
+        >
+          <Pill.Group>
+            {chips.map(chip => (
+              <Pill
+                key={chip.key}
+                withRemoveButton
+                onRemove={() => clearFacet(chip.key)}
+                aria-label={`${t('search.removeFilter')}: ${chip.label}`}
+              >
+                {chip.label}
+              </Pill>
+            ))}
+            <PillsInput.Field
+              value={inputValue}
+              placeholder={chips.length > 0 ? '' : t('header.search')}
+              onFocus={() => setOpened(true)}
+              onChange={e => handleSearchChange(e.currentTarget.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') setOpened(false);
+              }}
+            />
+          </Pill.Group>
+        </PillsInput>
+      </Popover.Target>
+
+      <Popover.Dropdown p="xs">
+        <div className="mb-2 flex flex-wrap gap-1">
+          {facets.map(facet => {
+            const Icon = FACET_ICONS[facet];
+            return (
+              <Button
+                key={facet}
+                size="compact-xs"
+                variant={activeFacet === facet ? 'light' : 'subtle'}
+                color={activeFacet === facet ? 'green' : 'gray'}
+                leftSection={<Icon size={14} aria-hidden="true" />}
+                onClick={() => {
+                  setActiveFacet(facet);
+                  setFacetQuery('');
+                }}
+              >
+                {t(`search.${facet}`)}
+              </Button>
+            );
+          })}
+        </div>
+        {renderPanel()}
+      </Popover.Dropdown>
+    </Popover>
+  );
+};

--- a/frontend/src/components/layout/SearchBar.tsx
+++ b/frontend/src/components/layout/SearchBar.tsx
@@ -1,6 +1,5 @@
 import { useLanguage } from '@/contexts/LanguageContext';
-import { useAllCollections } from '@/hooks/useCollections';
-import { useCategoryFacets, useItemOwners } from '@/hooks/useSearchFacets';
+import { useSearchFacets } from '@/hooks/useSearchFacets';
 import { categoryTranslationKeys, getCategoryIcon } from '@/lib/categoryIcons';
 import { cn } from '@/lib/utils';
 import {
@@ -23,15 +22,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 // Types & constants
 // ---------------------------------------------------------------------------
 
-type Facet = 'owner' | 'collection' | 'category' | 'availability';
-
-const AVAILABILITY_OPTIONS = ['available', 'rented', 'sold'] as const;
+type Facet = 'category' | 'collection' | 'availability' | 'owner';
 
 const FACET_ICONS: Record<Facet, LucideIcon> = {
-  owner: User,
-  collection: BookMarked,
   category: Tag,
+  collection: BookMarked,
   availability: CircleDot,
+  owner: User,
 };
 
 // The browse/results page that the header search drives.
@@ -70,8 +67,8 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
   const facets: Facet[] = useMemo(
     () =>
       showOwner
-        ? ['owner', 'collection', 'category', 'availability']
-        : ['collection', 'category', 'availability'],
+        ? ['category', 'collection', 'availability', 'owner']
+        : ['category', 'collection', 'availability'],
     [showOwner],
   );
   const [activeFacet, setActiveFacet] = useState<Facet>(facets[0]);
@@ -89,19 +86,27 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
   }
 
   // ---------------------------------------------------------------------------
-  // Data for the facet lists
+  // Cross-filtered facet data (each facet reflects the other active filters)
   // ---------------------------------------------------------------------------
 
-  const ownersQuery = useItemOwners({ enabled: (opened && showOwner) || !!ownerId });
-  const collectionsQuery = useAllCollections({ enabled: opened || !!collectionId });
-  const categoriesQuery = useCategoryFacets({ enabled: opened });
+  const facetsQuery = useSearchFacets(
+    {
+      category: categoryValue,
+      collection: collectionId,
+      owner: ownerId,
+      availability: availabilityValue,
+      search: searchValue || undefined,
+    },
+    { enabled: opened || !!ownerId || !!collectionId },
+  );
+  const facetsData = facetsQuery.data;
 
   const resolveOwnerLabel = (id: string) => {
-    const owner = ownersQuery.data?.find(o => o.id === id);
+    const owner = facetsData?.owners.find(o => o.id === id);
     return owner ? owner.name || owner.username : '…';
   };
   const resolveCollectionLabel = (id: string) => {
-    const collection = collectionsQuery.data?.find(c => String(c.id) === id);
+    const collection = facetsData?.collections.find(c => c.id === id);
     return collection ? `${collection.name} (${collection.owner})` : '…';
   };
 
@@ -137,38 +142,43 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
     }, 300);
   };
 
-  const selectFacet = (key: Facet, value: string) => {
-    applyParams(params => params.set(key, value));
+  // Toggle a facet value: selecting the active value clears it. The popup stays
+  // open so the other facets visibly update with the new selection.
+  const toggleFacet = (key: Facet, value: string) => {
+    const isActive = currentParams.get(key) === value;
+    applyParams(params => {
+      if (isActive) params.delete(key);
+      else params.set(key, value);
+    });
     setFacetQuery('');
-    setOpened(false);
   };
 
   const clearFacet = (key: string) => applyParams(params => params.delete(key), { replace: true });
 
   // ---------------------------------------------------------------------------
-  // Active filter chips
+  // Active filter chips (ordered like the facet tabs)
   // ---------------------------------------------------------------------------
 
   const chips: { key: string; label: string }[] = [];
-  if (ownerId) chips.push({ key: 'owner', label: resolveOwnerLabel(ownerId) });
-  if (collectionId) chips.push({ key: 'collection', label: resolveCollectionLabel(collectionId) });
   if (categoryValue && categoryValue !== 'all')
     chips.push({
       key: 'category',
       label: t(categoryTranslationKeys[categoryValue] ?? categoryValue),
     });
+  if (collectionId) chips.push({ key: 'collection', label: resolveCollectionLabel(collectionId) });
   if (availabilityValue)
     chips.push({ key: 'availability', label: t(`search.availability.${availabilityValue}`) });
+  if (ownerId) chips.push({ key: 'owner', label: resolveOwnerLabel(ownerId) });
 
   // ---------------------------------------------------------------------------
   // Facet panel rendering
   // ---------------------------------------------------------------------------
 
   const facetSearchPlaceholder: Record<Facet, string> = {
-    owner: t('search.searchOwners'),
-    collection: t('search.searchCollections'),
     category: t('search.searchCategories'),
+    collection: t('search.searchCollections'),
     availability: '',
+    owner: t('search.searchOwners'),
   };
 
   const renderRow = (
@@ -176,12 +186,14 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
     {
       icon,
       label,
+      secondary,
       meta,
       active,
       onSelect,
     }: {
       icon?: React.ReactNode;
       label: string;
+      secondary?: string;
       meta?: string;
       active: boolean;
       onSelect: () => void;
@@ -196,7 +208,10 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
       )}
     >
       {icon}
-      <span className="flex-1 truncate text-sm">{label}</span>
+      <span className="min-w-0 flex-1 truncate text-sm">
+        {label}
+        {secondary && <span className="ml-1 text-muted-foreground">{secondary}</span>}
+      </span>
       {meta && (
         <Text span size="xs" c="dimmed" className="shrink-0">
           {meta}
@@ -210,30 +225,21 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
     const query = facetQuery.trim().toLowerCase();
 
     if (activeFacet === 'availability') {
-      return (
-        <div className="flex flex-col">
-          {AVAILABILITY_OPTIONS.map(value =>
-            renderRow(value, {
-              icon: <CircleDot size={16} className="text-muted-foreground" />,
-              label: t(`search.availability.${value}`),
-              active: availabilityValue === value,
-              onSelect: () => selectFacet('availability', value),
-            }),
-          )}
-        </div>
+      const rows = (facetsData?.availability ?? []).map(({ value, count }) =>
+        renderRow(value, {
+          icon: <CircleDot size={16} className="text-muted-foreground" />,
+          label: t(`search.availability.${value}`),
+          meta: `(${count})`,
+          active: availabilityValue === value,
+          onSelect: () => toggleFacet('availability', value),
+        }),
       );
+      return <div className="flex flex-col">{rows}</div>;
     }
-
-    const loading =
-      activeFacet === 'owner'
-        ? ownersQuery.isLoading
-        : activeFacet === 'collection'
-          ? collectionsQuery.isLoading
-          : categoriesQuery.isLoading;
 
     let rows: React.ReactNode[] = [];
     if (activeFacet === 'owner') {
-      rows = (ownersQuery.data ?? [])
+      rows = (facetsData?.owners ?? [])
         .filter(
           o =>
             !query ||
@@ -244,25 +250,26 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
           renderRow(o.id, {
             icon: <User size={16} className="text-muted-foreground" />,
             label: o.name || o.username,
-            meta: String(o.item_count),
+            meta: `(${o.count})`,
             active: ownerId === o.id,
-            onSelect: () => selectFacet('owner', o.id),
+            onSelect: () => toggleFacet('owner', o.id),
           }),
         );
     } else if (activeFacet === 'collection') {
-      rows = (collectionsQuery.data ?? [])
+      rows = (facetsData?.collections ?? [])
         .filter(c => !query || c.name.toLowerCase().includes(query))
         .map(c =>
-          renderRow(String(c.id), {
+          renderRow(c.id, {
             icon: <BookMarked size={16} className="text-muted-foreground" />,
             label: c.name,
-            meta: `(${c.owner})`,
-            active: collectionId === String(c.id),
-            onSelect: () => selectFacet('collection', String(c.id)),
+            secondary: `(${c.owner})`,
+            meta: `(${c.count})`,
+            active: collectionId === c.id,
+            onSelect: () => toggleFacet('collection', c.id),
           }),
         );
     } else {
-      rows = (categoriesQuery.data ?? [])
+      rows = (facetsData?.categories ?? [])
         .map(facet => {
           const label = t(categoryTranslationKeys[facet.category] ?? facet.category);
           return { facet, label };
@@ -275,7 +282,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
             label,
             meta: `(${facet.count})`,
             active: categoryValue === facet.category,
-            onSelect: () => selectFacet('category', facet.category),
+            onSelect: () => toggleFacet('category', facet.category),
           });
         });
     }
@@ -289,7 +296,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
           leftSection={<Search size={14} aria-hidden="true" />}
           onChange={e => setFacetQuery(e.currentTarget.value)}
         />
-        {loading ? (
+        {facetsQuery.isLoading ? (
           <div className="flex justify-center py-4">
             <Loader size="sm" />
           </div>

--- a/frontend/src/components/layout/SearchBar.tsx
+++ b/frontend/src/components/layout/SearchBar.tsx
@@ -5,17 +5,17 @@ import { cn } from '@/lib/utils';
 import {
   Button,
   Loader,
+  NavLink,
   Pill,
   PillsInput,
   Popover,
   ScrollArea,
   Text,
   TextInput,
-  UnstyledButton,
 } from '@mantine/core';
-import { BookMarked, Check, CircleDot, Search, Tag, User } from 'lucide-react';
+import { BookMarked, CircleDot, Search, Tag, User } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 // ---------------------------------------------------------------------------
@@ -31,12 +31,16 @@ const FACET_ICONS: Record<Facet, LucideIcon> = {
   owner: User,
 };
 
+// Facets that require an authenticated user (collections are auth-only, owners
+// are intentionally hidden from anonymous visitors).
+const AUTHED_FACETS: readonly Facet[] = ['collection', 'owner'];
+
 // The browse/results page that the header search drives.
 const BROWSE_PATH = '/';
 
 interface SearchBarProps {
-  /** Whether the owner facet is offered (logged-in users only). */
-  showOwner: boolean;
+  /** Whether the viewer is logged in (gates the collection and owner facets). */
+  loggedIn: boolean;
   className?: string;
 }
 
@@ -44,7 +48,7 @@ interface SearchBarProps {
 // Component
 // ---------------------------------------------------------------------------
 
-export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
+export const SearchBar = ({ loggedIn, className }: SearchBarProps) => {
   const { t } = useLanguage();
   const navigate = useNavigate();
   const location = useLocation();
@@ -66,10 +70,10 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
   const [opened, setOpened] = useState(false);
   const facets: Facet[] = useMemo(
     () =>
-      showOwner
-        ? ['category', 'collection', 'availability', 'owner']
-        : ['category', 'collection', 'availability'],
-    [showOwner],
+      (['category', 'collection', 'availability', 'owner'] as const).filter(
+        facet => loggedIn || !AUTHED_FACETS.includes(facet),
+      ),
+    [loggedIn],
   );
   const [activeFacet, setActiveFacet] = useState<Facet>(facets[0]);
   const [facetQuery, setFacetQuery] = useState('');
@@ -77,6 +81,13 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
   // Free-text item search (mirrors the URL `search` param, debounced).
   const [inputValue, setInputValue] = useState(searchValue);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Clear any pending debounce on unmount so it can't fire after navigation.
+  useEffect(
+    () => () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    },
+    [],
+  );
   // Adopt the URL value whenever it changes externally (back/forward, chips),
   // without an effect — React's "adjusting state when a prop changes" pattern.
   const [lastSyncedSearch, setLastSyncedSearch] = useState(searchValue);
@@ -191,7 +202,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
       active,
       onSelect,
     }: {
-      icon?: React.ReactNode;
+      icon: React.ReactNode;
       label: string;
       secondary?: string;
       meta?: string;
@@ -199,26 +210,42 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
       onSelect: () => void;
     },
   ) => (
-    <UnstyledButton
+    <NavLink
       key={key}
+      component="button"
+      type="button"
+      active={active}
+      variant="light"
+      color="green"
       onClick={onSelect}
-      className={cn(
-        'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-[var(--mantine-color-default-hover)]',
-        active && 'bg-[var(--mantine-color-default-hover)]',
-      )}
-    >
-      {icon}
-      <span className="min-w-0 flex-1 truncate text-sm">
-        {label}
-        {secondary && <span className="ml-1 text-muted-foreground">{secondary}</span>}
-      </span>
-      {meta && (
-        <Text span size="xs" c="dimmed" className="shrink-0">
-          {meta}
-        </Text>
-      )}
-      {active && <Check size={14} className="shrink-0 text-[var(--mantine-color-green-6)]" />}
-    </UnstyledButton>
+      leftSection={icon}
+      rightSection={
+        meta ? (
+          <Text span size="xs" c="dimmed">
+            {meta}
+          </Text>
+        ) : undefined
+      }
+      label={
+        <span className="truncate">
+          {label}
+          {secondary && (
+            <Text span inherit c="dimmed">
+              {' '}
+              {secondary}
+            </Text>
+          )}
+        </span>
+      }
+      styles={{
+        root: { borderRadius: 'var(--mantine-radius-sm)' },
+        label: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+      }}
+    />
+  );
+
+  const mutedIcon = (Icon: LucideIcon) => (
+    <Icon size={16} style={{ color: 'var(--mantine-color-dimmed)' }} aria-hidden="true" />
   );
 
   const renderPanel = () => {
@@ -227,7 +254,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
     if (activeFacet === 'availability') {
       const rows = (facetsData?.availability ?? []).map(({ value, count }) =>
         renderRow(value, {
-          icon: <CircleDot size={16} className="text-muted-foreground" />,
+          icon: mutedIcon(CircleDot),
           label: t(`search.availability.${value}`),
           meta: `(${count})`,
           active: availabilityValue === value,
@@ -248,7 +275,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
         )
         .map(o =>
           renderRow(o.id, {
-            icon: <User size={16} className="text-muted-foreground" />,
+            icon: mutedIcon(User),
             label: o.name || o.username,
             meta: `(${o.count})`,
             active: ownerId === o.id,
@@ -260,7 +287,7 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
         .filter(c => !query || c.name.toLowerCase().includes(query))
         .map(c =>
           renderRow(c.id, {
-            icon: <BookMarked size={16} className="text-muted-foreground" />,
+            icon: mutedIcon(BookMarked),
             label: c.name,
             secondary: `(${c.owner})`,
             meta: `(${c.count})`,
@@ -275,16 +302,15 @@ export const SearchBar = ({ showOwner, className }: SearchBarProps) => {
           return { facet, label };
         })
         .filter(({ label }) => !query || label.toLowerCase().includes(query))
-        .map(({ facet, label }) => {
-          const Icon = getCategoryIcon(facet.category);
-          return renderRow(facet.category, {
-            icon: <Icon size={16} className="text-muted-foreground" />,
+        .map(({ facet, label }) =>
+          renderRow(facet.category, {
+            icon: mutedIcon(getCategoryIcon(facet.category)),
             label,
             meta: `(${facet.count})`,
             active: categoryValue === facet.category,
             onSelect: () => toggleFacet('category', facet.category),
-          });
-        });
+          }),
+        );
     }
 
     return (

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -28,6 +28,22 @@ const translations = {
     'header.light': 'Light',
     'header.dark': 'Dark',
 
+    // Search bar / facets
+    'search.filterBy': 'Filter by',
+    'search.owner': 'Owner',
+    'search.collection': 'Collection',
+    'search.category': 'Category',
+    'search.availability': 'Availability',
+    'search.searchOwners': 'Search people…',
+    'search.searchCollections': 'Search collections…',
+    'search.searchCategories': 'Search categories…',
+    'search.noResults': 'No matches',
+    'search.loading': 'Loading…',
+    'search.availability.available': 'Available',
+    'search.availability.rented': 'Rented',
+    'search.availability.sold': 'Sold',
+    'search.removeFilter': 'Remove filter',
+
     // Auth
     'auth.signIn': 'Sign In',
     'auth.signUp': 'Sign Up',
@@ -600,6 +616,22 @@ const translations = {
     'header.theme': 'Design',
     'header.light': 'Hell',
     'header.dark': 'Dunkel',
+
+    // Search bar / facets
+    'search.filterBy': 'Filtern nach',
+    'search.owner': 'Anbieter',
+    'search.collection': 'Sammlung',
+    'search.category': 'Kategorie',
+    'search.availability': 'Verfügbarkeit',
+    'search.searchOwners': 'Personen suchen…',
+    'search.searchCollections': 'Sammlungen suchen…',
+    'search.searchCategories': 'Kategorien suchen…',
+    'search.noResults': 'Keine Treffer',
+    'search.loading': 'Wird geladen…',
+    'search.availability.available': 'Verfügbar',
+    'search.availability.rented': 'Vermietet',
+    'search.availability.sold': 'Verkauft',
+    'search.removeFilter': 'Filter entfernen',
 
     // Auth
     'auth.signIn': 'Anmelden',

--- a/frontend/src/hooks/useItems.tsx
+++ b/frontend/src/hooks/useItems.tsx
@@ -1,5 +1,6 @@
 import {
   publicItemsList,
+  type PublicItemsListData,
   type StatusB0aEnum,
   type ConditionEnum,
   type SalesTypeEnum,
@@ -17,6 +18,8 @@ export const useItems = ({
   salesTypes,
   conditions,
   ordering,
+  owner,
+  collection,
 }: {
   category?: ItemCategory;
   search?: string;
@@ -27,6 +30,10 @@ export const useItems = ({
   salesTypes?: SalesTypeEnum[];
   conditions?: ConditionEnum[];
   ordering?: string;
+  /** Restrict to items owned by this user id. */
+  owner?: string;
+  /** Restrict to items contained in this collection id. */
+  collection?: string;
 } = {}) => {
   const normalizedStatus =
     status === undefined ? undefined : Array.isArray(status) ? status : [status];
@@ -48,10 +55,14 @@ export const useItems = ({
         salesTypes: salesTypesSorted,
         conditions: conditionsSorted,
         ordering,
+        owner,
+        collection,
       },
     ],
     queryFn: async () => {
       const response = await publicItemsList({
+        // `collection` is a valid backend filter that is not yet part of the
+        // generated query type, so the object is widened before being passed.
         query: {
           category,
           page: page,
@@ -62,7 +73,9 @@ export const useItems = ({
           sales_type: salesTypesSorted,
           conditions: conditionsSorted,
           ordering,
-        },
+          user: owner,
+          collection,
+        } as NonNullable<PublicItemsListData['query']> & { collection?: string },
       });
       return {
         items: response.data.results || [],

--- a/frontend/src/hooks/useSearchFacets.ts
+++ b/frontend/src/hooks/useSearchFacets.ts
@@ -1,0 +1,25 @@
+import { fetchCategoryFacets, fetchItemOwners } from '@/services/custom/search';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Owners of shared items, for the "owner" facet of the header search.
+ *
+ * Only meaningful for logged-in users, so callers should pass `enabled` to
+ * avoid firing the request for anonymous visitors.
+ */
+export const useItemOwners = ({ enabled = true }: { enabled?: boolean } = {}) =>
+  useQuery({
+    queryKey: ['public-items', 'owners'],
+    queryFn: fetchItemOwners,
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+/** Categories present among shared items, with item counts, for the search popup. */
+export const useCategoryFacets = ({ enabled = true }: { enabled?: boolean } = {}) =>
+  useQuery({
+    queryKey: ['public-items', 'category-facets'],
+    queryFn: fetchCategoryFacets,
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/frontend/src/hooks/useSearchFacets.ts
+++ b/frontend/src/hooks/useSearchFacets.ts
@@ -1,25 +1,22 @@
-import { fetchCategoryFacets, fetchItemOwners } from '@/services/custom/search';
-import { useQuery } from '@tanstack/react-query';
+import { fetchSearchFacets, type SearchFacetParams } from '@/services/custom/search';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 /**
- * Owners of shared items, for the "owner" facet of the header search.
+ * Cross-filtered search facets for the header search popup.
  *
- * Only meaningful for logged-in users, so callers should pass `enabled` to
- * avoid firing the request for anonymous visitors.
+ * `params` is the currently active selection; each facet in the response is
+ * computed over the visible items narrowed by every *other* selection, so the
+ * options and counts update as filters are picked. Previous data is kept while
+ * refetching so the lists don't flash empty when a filter changes.
  */
-export const useItemOwners = ({ enabled = true }: { enabled?: boolean } = {}) =>
+export const useSearchFacets = (
+  params: SearchFacetParams,
+  { enabled = true }: { enabled?: boolean } = {},
+) =>
   useQuery({
-    queryKey: ['public-items', 'owners'],
-    queryFn: fetchItemOwners,
+    queryKey: ['public-items', 'facets', params],
+    queryFn: () => fetchSearchFacets(params),
     enabled,
-    staleTime: 5 * 60 * 1000,
-  });
-
-/** Categories present among shared items, with item counts, for the search popup. */
-export const useCategoryFacets = ({ enabled = true }: { enabled?: boolean } = {}) =>
-  useQuery({
-    queryKey: ['public-items', 'category-facets'],
-    queryFn: fetchCategoryFacets,
-    enabled,
-    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+    staleTime: 60 * 1000,
   });

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -116,7 +116,8 @@ const Index = () => {
   const collectionParam = params.get('collection') || undefined;
   const availabilityParam = params.get('availability');
   const availability: Availability | undefined =
-    availabilityParam && availabilityParam in AVAILABILITY_STATUSES
+    availabilityParam &&
+    Object.prototype.hasOwnProperty.call(AVAILABILITY_STATUSES, availabilityParam)
       ? (availabilityParam as Availability)
       : undefined;
 

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/services/django';
 import { Badge, Group, Pagination, SegmentedControl, Table, Text } from '@mantine/core';
 import { Grid3X3, List } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 // ---------------------------------------------------------------------------
@@ -49,6 +49,13 @@ const FEDERATED_PAGE_SIZE = 50;
 const DEFAULT_CONDITIONS: ConditionEnum[] = [0, 1];
 // statuses that count as "available": Available (2) and Reserved (3)
 const AVAILABLE_STATUSES: StatusB0aEnum[] = [2, 3];
+// Availability facet (header search) → item statuses it maps to.
+const AVAILABILITY_STATUSES = {
+  available: [2, 3],
+  rented: [4],
+  sold: [5],
+} satisfies Record<string, StatusB0aEnum[]>;
+type Availability = keyof typeof AVAILABILITY_STATUSES;
 const LS_KEY = 'indexViewMode';
 
 const VALID_CATEGORIES: ItemCategoryFilter[] = [
@@ -79,12 +86,10 @@ const Index = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { t, language } = useLanguage();
-  const [viewMode, setViewMode] = useState<'list' | 'cards'>('cards');
-
-  useEffect(() => {
+  const [viewMode, setViewMode] = useState<'list' | 'cards'>(() => {
     const saved = localStorage.getItem(LS_KEY) as 'list' | 'cards' | null;
-    if (saved) setViewMode(saved);
-  }, []);
+    return saved ?? 'cards';
+  });
 
   // ---------------------------------------------------------------------------
   // URL param parsing
@@ -105,6 +110,15 @@ const Index = () => {
   const categoryParam = params.get('category') as ItemCategoryFilter | null;
   const selectedCategory: ItemCategoryFilter =
     categoryParam && VALID_CATEGORIES.includes(categoryParam) ? categoryParam : 'all';
+
+  // Header-search facets reflected in the URL.
+  const ownerParam = params.get('owner') || undefined;
+  const collectionParam = params.get('collection') || undefined;
+  const availabilityParam = params.get('availability');
+  const availability: Availability | undefined =
+    availabilityParam && availabilityParam in AVAILABILITY_STATUSES
+      ? (availabilityParam as Availability)
+      : undefined;
 
   const onlyAvailable = (params.get('available') ?? '1') !== '0';
 
@@ -193,16 +207,23 @@ const Index = () => {
   const conditions: ConditionEnum[] | undefined =
     typeParam === 'buy' && selectedConditions.length > 0 ? selectedConditions : undefined;
 
+  // The availability facet (when set) wins over the "only available" toggle.
+  const statusFilter: StatusB0aEnum | StatusB0aEnum[] | undefined = availability
+    ? AVAILABILITY_STATUSES[availability]
+    : (itemFilters?.status ?? (onlyAvailable ? AVAILABLE_STATUSES : undefined));
+
   const itemsQuery = useItems({
     category: selectedCategory === 'all' ? undefined : selectedCategory,
     conditions,
     search: searchQuery,
     page: currentPage,
-    status: itemFilters?.status ?? (onlyAvailable ? AVAILABLE_STATUSES : undefined),
+    status: statusFilter,
     minPrice: itemFilters?.minPrice,
     maxPrice: itemFilters?.maxPrice,
     salesTypes: itemFilters?.salesTypes,
     ordering,
+    owner: ownerParam,
+    collection: collectionParam,
   });
 
   const federatedQuery = useFederatedItems(

--- a/frontend/src/services/custom/search.ts
+++ b/frontend/src/services/custom/search.ts
@@ -1,0 +1,44 @@
+/**
+ * Search facet endpoints.
+ *
+ * Thin typed wrappers around the public-items facet endpoints that power the
+ * header search popup (owner and category facets). They live here — rather than
+ * in the generated SDK — because the SDK can only be regenerated against a live
+ * backend (`npm run types:openapi`); a future regeneration will fold these
+ * operations into `src/services/django` and these helpers can be retired.
+ *
+ * They reuse the shared, pre-configured `client` so credentials, CSRF and the
+ * Accept-Language header are applied exactly like every generated SDK call.
+ */
+
+import { client } from '../django/client.gen';
+
+/** A user who owns at least one shared (published and visible) item. */
+export interface ItemOwner {
+  id: string;
+  username: string;
+  name: string;
+  item_count: number;
+}
+
+/** A category together with the number of shared items it contains. */
+export interface CategoryFacet {
+  category: string;
+  count: number;
+}
+
+/** Fetch every owner of visible published items, with their item counts. */
+export const fetchItemOwners = async (): Promise<ItemOwner[]> => {
+  const { data } = await client.get<{ 200: ItemOwner[] }>({
+    url: '/api/public-items/owners/',
+  });
+  return data ?? [];
+};
+
+/** Fetch every category present among visible published items, with counts. */
+export const fetchCategoryFacets = async (): Promise<CategoryFacet[]> => {
+  const { data } = await client.get<{ 200: CategoryFacet[] }>({
+    url: '/api/public-items/categories/',
+  });
+  return data ?? [];
+};

--- a/frontend/src/services/custom/search.ts
+++ b/frontend/src/services/custom/search.ts
@@ -1,44 +1,84 @@
 /**
- * Search facet endpoints.
+ * Search facets endpoint.
  *
- * Thin typed wrappers around the public-items facet endpoints that power the
- * header search popup (owner and category facets). They live here — rather than
- * in the generated SDK — because the SDK can only be regenerated against a live
- * backend (`npm run types:openapi`); a future regeneration will fold these
- * operations into `src/services/django` and these helpers can be retired.
+ * Thin typed wrapper around the public-items `facets` endpoint that powers the
+ * header search popup. It returns every facet (category, collection,
+ * availability, owner) cross-filtered by the *other* active selections, so the
+ * options and counts on offer update as filters are picked.
  *
- * They reuse the shared, pre-configured `client` so credentials, CSRF and the
- * Accept-Language header are applied exactly like every generated SDK call.
+ * It lives here — rather than in the generated SDK — because the SDK can only be
+ * regenerated against a live backend (`npm run types:openapi`); a future
+ * regeneration will fold this operation into `src/services/django` and this
+ * helper can be retired. It reuses the shared, pre-configured `client` so
+ * credentials, CSRF and the Accept-Language header are applied exactly like
+ * every generated SDK call.
  */
 
 import { client } from '../django/client.gen';
 
-/** A user who owns at least one shared (published and visible) item. */
-export interface ItemOwner {
-  id: string;
-  username: string;
-  name: string;
-  item_count: number;
-}
-
-/** A category together with the number of shared items it contains. */
+/** A category and the number of matching shared items. */
 export interface CategoryFacet {
   category: string;
   count: number;
 }
 
-/** Fetch every owner of visible published items, with their item counts. */
-export const fetchItemOwners = async (): Promise<ItemOwner[]> => {
-  const { data } = await client.get<{ 200: ItemOwner[] }>({
-    url: '/api/public-items/owners/',
-  });
-  return data ?? [];
+/** A collection (with its owner) and the number of matching items it contains. */
+export interface CollectionFacet {
+  id: string;
+  name: string;
+  owner: string;
+  count: number;
+}
+
+/** An owner and the number of their matching shared items. */
+export interface OwnerFacet {
+  id: string;
+  username: string;
+  name: string;
+  count: number;
+}
+
+/** An availability value (`available` | `rented` | `sold`) and its item count. */
+export interface AvailabilityFacet {
+  value: string;
+  count: number;
+}
+
+/** The complete set of search facets, each excluding its own active filter. */
+export interface SearchFacets {
+  categories: CategoryFacet[];
+  collections: CollectionFacet[];
+  availability: AvailabilityFacet[];
+  owners: OwnerFacet[];
+}
+
+/** The currently active filter selection, used to cross-filter the facets. */
+export interface SearchFacetParams {
+  category?: string;
+  collection?: string;
+  owner?: string;
+  availability?: string;
+  search?: string;
+}
+
+const EMPTY_FACETS: SearchFacets = {
+  categories: [],
+  collections: [],
+  availability: [],
+  owners: [],
 };
 
-/** Fetch every category present among visible published items, with counts. */
-export const fetchCategoryFacets = async (): Promise<CategoryFacet[]> => {
-  const { data } = await client.get<{ 200: CategoryFacet[] }>({
-    url: '/api/public-items/categories/',
+/** Fetch all search facets cross-filtered by the given active selection. */
+export const fetchSearchFacets = async (params: SearchFacetParams): Promise<SearchFacets> => {
+  const { data } = await client.get<{ 200: SearchFacets }>({
+    url: '/api/public-items/facets/',
+    query: {
+      category: params.category,
+      collection: params.collection,
+      owner: params.owner,
+      availability: params.availability,
+      search: params.search,
+    },
   });
-  return data ?? [];
+  return data ?? EMPTY_FACETS;
 };


### PR DESCRIPTION
## Summary

Improves the top search bar so that clicking it opens a popup where you can choose **what** to filter by — **category, collection, availability, owner** — alongside the existing free‑text item search. Every selected filter is reflected in the URL, and the URL drives the UI, so filters are shareable and survive reloads and back/forward navigation.

## What's new

Clicking the header search opens a popup with facet tabs, in order:

- **Category** — all categories with the **item count in brackets**.
- **Collection** — all viewable collections; type to search, with the collection **owner shown in brackets** (plus a count).
- **Availability** — available, rented or sold (with counts).
- **Owner** *(logged‑in users only)* — every user with shared items; type to search, with a per‑owner count.

Each active filter shows as a removable chip in the bar, and free‑text item search keeps working alongside the chips.

### Cross-filtering
Selecting a value keeps the popup open and **updates the other facets** to match: e.g. picking the collection "Favorite Tools" narrows the category, availability and owner lists (and their counts) to just that collection's items, while the collection list itself stays switchable. Each facet is computed over the visible items narrowed by every *other* active selection, but never by its own dimension.

### URL ⇄ UI sync
Selecting a facet writes its query param (`category`, `collection`, `availability`, `owner`) and navigates to the browse page; the bar and the results both rehydrate from those params. Removing a chip clears the param. The availability facet (available → Available/Reserved, rented → Rented, sold → Sold) takes precedence over the existing "only available" toggle when set.

## Backend

- `GET /api/public-items/facets/` — returns the category, collection, availability and owner facets together, each cross‑filtered by the other active selections (`category`/`collection`/`owner`/`availability`/`search` query params). Collections are limited to those the requester may view; all facets reuse the existing visibility‑aware queryset so they only surface items the requester can see.
- New `collection` filter on the item filterset (`?collection=<uuid>`), restricting results to a collection.

Tests (`PublicItemFacetTestCase`) cover the unfiltered facets, cross‑filter narrowing by collection and by category, draft‑only owner exclusion, and the collection filter.

> Note: the facets endpoint is consumed through a small typed wrapper in `frontend/src/services/custom/search.ts` (alongside the existing `auth`/`images` custom services) because the generated SDK can only be regenerated against a live backend. Running `npm run types:openapi` once deployed will fold it into `src/services/django`, after which the wrapper can be retired.

## Testing

- Backend: `ruff check` + `ruff format` clean; facet/cross‑filter/collection tests added (CI's pytest job runs them in Docker — they could not be executed locally here as the environment has no Django/Docker daemon).
- Frontend: no new `tsc` errors, ESLint clean on changed files, production `vite build` succeeds, Prettier clean.

https://claude.ai/code/session_0151UgGBWayrfwXqcSPeo13r

---
_Generated by [Claude Code](https://claude.ai/code/session_0151UgGBWayrfwXqcSPeo13r)_