### PR TITLE
perf(items): speed up item loading — fix N+1s, consolidate facet counts, add index

### DIFF
--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -280,12 +280,22 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
 
         count = models.Count("id", distinct=True)
 
+        # Count every type preset in a single query via conditional aggregation
+        # instead of one COUNT(*) per preset.
         type_base = narrowed("type")
-        types = []
-        for value, sales_types in TYPE_SALES_TYPES.items():
-            value_count = type_base.filter(sales_type__in=sales_types).count()
-            if value_count:
-                types.append({"value": value, "count": value_count})
+        type_counts = type_base.aggregate(
+            **{
+                value: models.Count(
+                    "id", filter=models.Q(sales_type__in=sales_types), distinct=True
+                )
+                for value, sales_types in TYPE_SALES_TYPES.items()
+            }
+        )
+        types = [
+            {"value": value, "count": type_counts[value]}
+            for value in TYPE_SALES_TYPES
+            if type_counts[value]
+        ]
 
         categories = [
             {"category": row["category"], "count": row["count"]}
@@ -330,12 +340,21 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
             .order_by("user__username")
         ]
 
+        # Same single-query conditional aggregation for the availability presets.
         availability_base = narrowed("availability")
-        availability_facets = []
-        for value, statuses in AVAILABILITY_STATUSES.items():
-            value_count = availability_base.filter(status__in=statuses).count()
-            if value_count:
-                availability_facets.append({"value": value, "count": value_count})
+        availability_counts = availability_base.aggregate(
+            **{
+                value: models.Count(
+                    "id", filter=models.Q(status__in=statuses), distinct=True
+                )
+                for value, statuses in AVAILABILITY_STATUSES.items()
+            }
+        )
+        availability_facets = [
+            {"value": value, "count": availability_counts[value]}
+            for value in AVAILABILITY_STATUSES
+            if availability_counts[value]
+        ]
 
         data = {
             "types": types,

--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -194,7 +194,9 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
     def get_queryset(self):
         user = self.request.user
         base_qs = (
-            Item.objects.published().select_related("user").prefetch_related("images")
+            Item.objects.published()
+            .select_related("user", "location")
+            .prefetch_related("images")
         )
 
         if not user.is_authenticated:
@@ -354,7 +356,7 @@ class ItemViewSet(viewsets.ModelViewSet, ItemBaseViewSet):
         """Return items belonging to the authenticated user."""
         return (
             Item.objects.get_for_user(self.request.user)
-            .select_related("user")
+            .select_related("user", "location")
             .prefetch_related("images")
         )
 

--- a/backend/bubble/items/migrations/0016_item_items_status_created_idx.py
+++ b/backend/bubble/items/migrations/0016_item_items_status_created_idx.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("items", "0015_migrate_book_shelves_to_locations"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="item",
+            index=models.Index(
+                fields=["status", "-created_at"],
+                name="items_status_created_idx",
+            ),
+        ),
+    ]

--- a/backend/bubble/items/models.py
+++ b/backend/bubble/items/models.py
@@ -327,6 +327,14 @@ class Item(models.Model):
 
     class Meta:
         ordering = ["-created_at"]
+        indexes = [
+            # The item list endpoints filter by published ``status`` and order by
+            # ``-created_at``; this composite index serves both in one scan.
+            models.Index(
+                fields=["status", "-created_at"],
+                name="items_status_created_idx",
+            ),
+        ]
         constraints = [
             # donate and borrow require price to be null
             models.CheckConstraint(

--- a/backend/bubble/items/models.py
+++ b/backend/bubble/items/models.py
@@ -370,7 +370,19 @@ class Item(models.Model):
         return bool(self.name and self.category)
 
     def get_first_image(self):
-        """Return the first image of the item based on ordering."""
+        """Return the first image of the item based on ordering.
+
+        When the item's images have been prefetched (e.g. in the list
+        endpoints), read from the prefetch cache instead of issuing a fresh
+        query. ``Image.Meta.ordering`` already orders by ``("item", "ordering")``
+        so the first cached image is the one with the lowest ordering — calling
+        ``.order_by("ordering")`` here would clone the queryset, discard the
+        prefetched result cache and trigger one extra query per item (a classic
+        N+1 across a page of results).
+        """
+        if "images" in getattr(self, "_prefetched_objects_cache", {}):
+            images = self.images.all()
+            return images[0] if images else None
         return self.images.order_by("ordering").first()
 
 

--- a/backend/bubble/items/tests/tests.py
+++ b/backend/bubble/items/tests/tests.py
@@ -1482,6 +1482,7 @@ class ItemListQueryCountTests(TestCase):
 
     def _count_queries_for(self, n_items):
         Item.objects.all().delete()
+        Location.objects.all().delete()
         owner = ItemOwnerUserFactory(
             username=f"owner{n_items}",
             email=f"owner{n_items}@example.com",

--- a/backend/bubble/items/tests/tests.py
+++ b/backend/bubble/items/tests/tests.py
@@ -8,7 +8,9 @@ from unittest.mock import patch
 
 from constance import config
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from PIL import Image as PILImage
 from rest_framework import status
@@ -17,7 +19,14 @@ from rest_framework.test import APIClient
 from bubble.collections.models import Collection, CollectionItem
 from bubble.core.permissions_config import DefaultGroup
 from bubble.items.ai.image_analyze import ItemImageResult
-from bubble.items.models import Image, Item, ItemStatus, SalesType, VisibilityType
+from bubble.items.models import (
+    Image,
+    Item,
+    ItemStatus,
+    Location,
+    SalesType,
+    VisibilityType,
+)
 from bubble.items.tests.factories import ItemOwnerUserFactory
 from bubble.users.tests.factories import UserFactory
 
@@ -1424,3 +1433,77 @@ class PublicItemFacetTestCase(TestCase):
         assert response.status_code == status.HTTP_200_OK
         names = {item["name"] for item in response.json()["results"]}
         assert names == {self.alice_tool.name, self.alice_book.name}
+
+
+class ItemListQueryCountTests(TestCase):
+    """Guard the item list endpoints against per-item (N+1) query growth.
+
+    The public item list serializes ``first_image`` and ``location_detail`` for
+    every row. Both used to issue an extra query per item — ``get_first_image``
+    re-ordered the queryset (busting the prefetch cache) and ``location_detail``
+    had no ``select_related``. These tests assert the query count stays constant
+    as the number of items grows, so a regression shows up immediately.
+    """
+
+    def setUp(self):
+        # The list is fetched anonymously; allow anonymous access to PUBLIC items.
+        config.REQUIRE_LOGIN = False
+
+    @staticmethod
+    def _jpeg_bytes():
+        """Return the bytes of a tiny valid JPEG (so thumbnail URLs resolve)."""
+        buf = BytesIO()
+        PILImage.new("RGB", (10, 10), color="blue").save(buf, format="JPEG")
+        return buf.getvalue()
+
+    def _make_item(self, owner, idx):
+        location = Location.objects.create(name=f"Shelf {idx}")
+        item = Item.objects.create(
+            name=f"Item {idx}",
+            description="desc",
+            user=owner,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            location=location,
+        )
+        # Two images so ordering actually has something to choose from.
+        for ordering in (1, 0):
+            Image.objects.create(
+                item=item,
+                original=SimpleUploadedFile(
+                    f"img-{idx}-{ordering}.jpg",
+                    self._jpeg_bytes(),
+                    content_type="image/jpeg",
+                ),
+                ordering=ordering,
+            )
+        return item
+
+    def _count_queries_for(self, n_items):
+        Item.objects.all().delete()
+        owner = ItemOwnerUserFactory(
+            username=f"owner{n_items}",
+            email=f"owner{n_items}@example.com",
+            password=TEST_PASSWORD,
+        )
+        for idx in range(n_items):
+            self._make_item(owner, idx)
+
+        client = APIClient()
+        url = reverse("api:public-item-list")
+        # Make sure the page is large enough to hold every item created.
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(url, {"page_size": 100})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == n_items
+        return len(ctx.captured_queries)
+
+    def test_public_list_query_count_is_constant(self):
+        """A page of 1 item and a page of 5 items issue the same #queries."""
+        baseline = self._count_queries_for(1)
+        larger = self._count_queries_for(5)
+        assert larger == baseline, (
+            f"Item list query count grows with rows (N+1): "
+            f"{baseline} queries for 1 item vs {larger} for 5"
+        )


### PR DESCRIPTION
## Summary

Performance work on the item loading / search API. All changes are query-level optimizations with no change to response shapes.

### 1. Eliminate N+1 queries in the item list endpoints
A page of 20 items issued ~40 unnecessary queries:

- **`Item.get_first_image()`** called `.order_by("ordering").first()`, which clones the queryset and **discards the prefetched `images` cache**, forcing one query per item. It now reads from the prefetch cache when images are prefetched (`Image.Meta.ordering` already orders by `("item", "ordering")`), falling back to the ordered query on the non-prefetched paths (AI describe, signals).
- **`ItemListSerializer` serializes `location_detail`**, but the querysets only `select_related("user")`. Added `"location"` so the FK joins in the main query instead of lazy-loading per row.

### 2. Consolidate facet count queries
The `facets` endpoint ran one `COUNT(*)` per preset for the type (×3) and availability (×3) facets — 6 queries. Both are now a single conditional-aggregation query each (`Count` with a per-preset `filter`), cutting ~4 queries off the endpoint. `distinct=True` keeps counts correct when the collection m2m join is active, matching the existing category/owner aggregations.

### 3. Composite index on `(status, -created_at)`
The list endpoints filter by published `status` and order by `-created_at`. A new `items_status_created_idx` index serves both the filter and the sort from one scan (migration `0016`).

## Testing
- Added `ItemListQueryCountTests` — asserts the public list endpoint's query count stays **constant** as the number of rows grows (locks in the N+1 fix against regressions).
- Ran the full `items` + `collections` suites against PostgreSQL + Redis: **108 passed**.
- `makemigrations --check` reports no missing migrations; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp3gosixtwpM9ofBtW7QKM)_