### PR TITLE
perf(items): serve lighter scaled-down preview images on item detail

### DIFF
--- a/backend/bubble/items/models.py
+++ b/backend/bubble/items/models.py
@@ -9,7 +9,7 @@ from djmoney.models.fields import MoneyField
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from guardian.shortcuts import assign_perm, get_objects_for_user
 from imagekit.models import ImageSpecField
-from imagekit.processors import ResizeToCover, ResizeToFill
+from imagekit.processors import ResizeToFill, ResizeToFit
 from PIL import ImageOps as PILImageOps
 from simple_history.models import HistoricalRecords
 
@@ -422,17 +422,23 @@ class Image(models.Model):
     item = models.ForeignKey(Item, on_delete=models.CASCADE, related_name="images")
     ordering = models.IntegerField(default=0)
 
+    # Small grid/card thumbnail. Cropped to a fixed box.
     thumbnail = ImageSpecField(
         source="original",
         processors=[ExifTranspose(), ResizeToFill(300, 200)],
         format="JPEG",
-        options={"quality": 88},
+        options={"quality": 80, "optimize": True, "progressive": True},
     )
+    # Scaled-down image served on the item detail page. ``ResizeToFit`` bounds
+    # the longest edge to 1200px (without upscaling smaller originals), which
+    # produces a much lighter file than the full-resolution original while
+    # staying sharp on typical viewports. ``optimize``/``progressive`` shave
+    # off additional bytes and let the image render top-to-bottom as it loads.
     preview = ImageSpecField(
         source="original",
-        processors=[ExifTranspose(), ResizeToCover(1200, 1200)],
+        processors=[ExifTranspose(), ResizeToFit(1200, 1200, upscale=False)],
         format="JPEG",
-        options={"quality": 88},
+        options={"quality": 80, "optimize": True, "progressive": True},
     )
 
     class Meta:


### PR DESCRIPTION
## Summary

Item detail pages felt like they load the full-resolution original image. In fact the detail carousel already loads the `preview` image spec (an imagekit `/media/CACHE/…` derivative, not the raw original) — but that spec was heavier than it needed to be, so the perceived difference between it and the original was small.

The `preview` spec used `ResizeToCover(1200, 1200)` at quality 88 with no encoder optimization. `ResizeToCover` sizes the image so its **shorter** edge reaches 1200px, so a typical 4000×3000 photo still rendered at 1600×1200 — much larger than the detail view needs.

This PR makes the preview genuinely small and fast:

- **`ResizeToFit(1200, 1200, upscale=False)`** — bounds the **longest** edge to 1200px instead of the shortest, so that same 4000×3000 photo becomes 1200×900. Smaller originals are no longer upscaled.
- **quality 80** (down from 88) — visually indistinguishable at this size, meaningfully fewer bytes.
- **`optimize` + `progressive` JPEG** — extra byte savings and top-to-bottom rendering as the image streams in.
- The same quality/optimize/progressive settings are applied to the grid **thumbnail** spec too.

The full-resolution `original` is still served only in the zoom lightbox (and only once it's opened), so there's no quality loss where users actually want detail.

## Why this is safe

- `ImageSpecField`s are virtual — no database migration is required.
- Changing the processors changes imagekit's cache key, so new derivatives are generated on demand (just-in-time); old cache files are simply left unused.
- No API contract change: the serializer still exposes `thumbnail` / `preview` / `original` exactly as before. The frontend carousel already uses `image.preview` for the inline detail view, so it picks up the lighter files automatically.

## Testing

- No existing tests assert preview dimensions/quality, so none needed updating.
- Docker/Python 3.14 aren't available in this environment to run the suite locally; CI will exercise the backend test suite. The change uses standard pilkit processors (`ResizeToFit`) that imagekit re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6CS4NshTdegUq4FNMTCB5)_