### PR TITLE
perf(item-detail): serve 1200px preview in the fullscreen image viewer

### DIFF
--- a/frontend/src/components/items/ItemImageCarousel.tsx
+++ b/frontend/src/components/items/ItemImageCarousel.tsx
@@ -235,7 +235,7 @@ export const ItemImageCarousel = ({ images, itemName }: ItemImageCarouselProps) 
                   className="flex items-center justify-center"
                 >
                   <img
-                    src={image.original || imageSrc(image)}
+                    src={imageSrc(image)}
                     alt={`${itemName} — ${index + 1}`}
                     onPointerDown={handlePointerDown}
                     onClick={e => {


### PR DESCRIPTION
The lightbox loaded `image.original`, i.e. the full-resolution upload, which is often several megabytes and slow to open. Serve the optimized ~1200px `preview` instead (falling back to the original only when no preview exists), matching the inline carousel. This keeps the zoom view sharp on typical screens while drastically reducing the download when opening an image.


Claude-Session: https://claude.ai/code/session_01C6CS4NshTdegUq4FNMTCB5