### PR TITLE
feat(frontend): add share button to item detail page

### DIFF
--- a/frontend/src/components/items/ShareButton.tsx
+++ b/frontend/src/components/items/ShareButton.tsx
@@ -1,0 +1,60 @@
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useShare } from '@/hooks/useShare';
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { Check, Share2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+interface ShareButtonProps {
+  /** Link to share. Defaults to the current page URL. */
+  url?: string;
+  title?: string;
+  text?: string;
+}
+
+/**
+ * Compact share action: opens the native share sheet on mobile, copies the
+ * link to the clipboard (with a confirmation notification) everywhere else.
+ */
+export function ShareButton({ url, title, text }: ShareButtonProps) {
+  const { t } = useLanguage();
+  const { share, canShareNatively } = useShare();
+  const [copied, setCopied] = useState(false);
+  const copiedTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(copiedTimeout.current), []);
+
+  const label = canShareNatively ? t('share.share') : t('share.copyLink');
+
+  const handleShare = async () => {
+    const outcome = await share({
+      url: url ?? window.location.href,
+      ...(title ? { title } : {}),
+      ...(text ? { text } : {}),
+    });
+
+    if (outcome === 'copied') {
+      notifications.show({ message: t('share.copied'), color: 'green' });
+      setCopied(true);
+      clearTimeout(copiedTimeout.current);
+      copiedTimeout.current = setTimeout(() => setCopied(false), 2000);
+    } else if (outcome === 'error') {
+      notifications.show({ message: t('share.failed'), color: 'red' });
+    }
+  };
+
+  return (
+    <Tooltip label={copied ? t('share.copied') : label}>
+      <ActionIcon
+        variant={copied ? 'filled' : 'light'}
+        color={copied ? 'green' : undefined}
+        size="lg"
+        aria-label={label}
+        data-testid="share-button"
+        onClick={() => void handleShare()}
+      >
+        {copied ? <Check size={18} /> : <Share2 size={18} />}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -650,6 +650,12 @@ const translations = {
     'calendar.hide': 'Hide',
     'calendar.secretHint': 'Anyone with this link can view the calendar — keep it private.',
     'calendar.loadError': 'Could not load the calendar link.',
+
+    // Sharing
+    'share.share': 'Share',
+    'share.copyLink': 'Copy link',
+    'share.copied': 'Link copied to clipboard',
+    'share.failed': 'Could not copy the link',
   },
   de: {
     // Header
@@ -1301,6 +1307,12 @@ const translations = {
     'calendar.hide': 'Ausblenden',
     'calendar.secretHint': 'Jeder mit diesem Link kann den Kalender sehen — halte ihn privat.',
     'calendar.loadError': 'Kalender-Link konnte nicht geladen werden.',
+
+    // Teilen
+    'share.share': 'Teilen',
+    'share.copyLink': 'Link kopieren',
+    'share.copied': 'Link in die Zwischenablage kopiert',
+    'share.failed': 'Link konnte nicht kopiert werden',
   },
 };
 

--- a/frontend/src/hooks/useShare.ts
+++ b/frontend/src/hooks/useShare.ts
@@ -1,6 +1,9 @@
-import { useIsMobile } from '@/hooks/use-mobile';
 import { copyToClipboard } from '@/lib/clipboard';
+import { useMediaQuery } from '@mantine/hooks';
 import { useCallback } from 'react';
+
+/** Mirrors the app's mobile breakpoint (see `useIsMobile`). */
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
 
 export interface ShareLinkData {
   url: string;
@@ -22,7 +25,9 @@ export type ShareOutcome = 'shared' | 'dismissed' | 'copied' | 'error';
  * unavailable) the link is copied to the clipboard instead.
  */
 export function useShare() {
-  const isMobile = useIsMobile();
+  // Evaluated during the first render (not in an effect), so the very first
+  // click already takes the native-share path on mobile.
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY, false, { getInitialValueInEffect: false });
   const canShareNatively = isMobile && typeof navigator !== 'undefined' && !!navigator.share;
 
   const share = useCallback(

--- a/frontend/src/hooks/useShare.ts
+++ b/frontend/src/hooks/useShare.ts
@@ -1,0 +1,49 @@
+import { useIsMobile } from '@/hooks/use-mobile';
+import { copyToClipboard } from '@/lib/clipboard';
+import { useCallback } from 'react';
+
+export interface ShareLinkData {
+  url: string;
+  title?: string;
+  text?: string;
+}
+
+/**
+ * - `shared`: the native share sheet handled the link
+ * - `dismissed`: the user closed the native share sheet without sharing
+ * - `copied`: the link was copied to the clipboard
+ * - `error`: the link could neither be shared nor copied
+ */
+export type ShareOutcome = 'shared' | 'dismissed' | 'copied' | 'error';
+
+/**
+ * Sharing of a link with the platform-appropriate behaviour: on mobile the
+ * native share sheet is opened, on desktop (or whenever the Web Share API is
+ * unavailable) the link is copied to the clipboard instead.
+ */
+export function useShare() {
+  const isMobile = useIsMobile();
+  const canShareNatively = isMobile && typeof navigator !== 'undefined' && !!navigator.share;
+
+  const share = useCallback(
+    async (data: ShareLinkData): Promise<ShareOutcome> => {
+      if (canShareNatively) {
+        try {
+          await navigator.share(data);
+          return 'shared';
+        } catch (error) {
+          // The user closing the share sheet is not a failure.
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return 'dismissed';
+          }
+          // Anything else (e.g. no share target) falls back to copying.
+        }
+      }
+
+      return (await copyToClipboard(data.url)) ? 'copied' : 'error';
+    },
+    [canShareNatively],
+  );
+
+  return { share, canShareNatively };
+}

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -8,6 +8,8 @@
  * Returns whether the value ended up in the clipboard.
  */
 export async function copyToClipboard(value: string): Promise<boolean> {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined') return false;
+
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(value);
@@ -17,8 +19,8 @@ export async function copyToClipboard(value: string): Promise<boolean> {
     // Permission denied or insecure context — try the legacy path below.
   }
 
+  const textarea = document.createElement('textarea');
   try {
-    const textarea = document.createElement('textarea');
     textarea.value = value;
     textarea.setAttribute('readonly', '');
     textarea.style.position = 'fixed';
@@ -26,10 +28,10 @@ export async function copyToClipboard(value: string): Promise<boolean> {
     textarea.style.opacity = '0';
     document.body.appendChild(textarea);
     textarea.select();
-    const copied = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    return copied;
+    return document.execCommand('copy');
   } catch {
     return false;
+  } finally {
+    textarea.remove();
   }
 }

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+/**
+ * Copy a string to the clipboard.
+ *
+ * Uses the async Clipboard API when available and falls back to a hidden
+ * textarea + `execCommand('copy')` for browsers/contexts where it is not
+ * (e.g. plain-http dev servers, older mobile browsers).
+ *
+ * Returns whether the value ended up in the clipboard.
+ */
+export async function copyToClipboard(value: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Permission denied or insecure context — try the legacy path below.
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return copied;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/pages/ItemDetail.tsx
+++ b/frontend/src/pages/ItemDetail.tsx
@@ -2,6 +2,7 @@ import { BookingDialog } from '@/components/items/BookingDialog';
 import { CalendarSubscribeButton } from '@/components/calendar/CalendarSubscribeButton';
 import { ItemImageCarousel } from '@/components/items/ItemImageCarousel';
 import { RentalCalendar } from '@/components/items/RentalCalendar';
+import { ShareButton } from '@/components/items/ShareButton';
 import {
   getSalesTypeBadgeProps,
   getStatusLabel,
@@ -114,6 +115,9 @@ const ItemDetail = () => {
     images,
   } = item;
 
+  // Canonical link to this item — without any hash/query of the current URL.
+  const shareUrl = `${window.location.origin}/item/${item.id}`;
+
   const isRental = sales_type === 'rent' || sales_type === 'borrow';
   const isWanted = sales_type === 'want_buy' || sales_type === 'want_rent';
   const hasImages = images.length > 0;
@@ -198,8 +202,11 @@ const ItemDetail = () => {
         <Button variant="subtle" onClick={() => navigate(-1)} leftSection={<ArrowLeft size={16} />}>
           {t('common.back')}
         </Button>
-        {/* Calendar subscription — any logged-in user, bookable items only */}
-        {user && isRental && itemUuid && <CalendarSubscribeButton kind="item" id={itemUuid} />}
+        <div className="flex items-center gap-2">
+          <ShareButton url={shareUrl} title={name} text={description || undefined} />
+          {/* Calendar subscription — any logged-in user, bookable items only */}
+          {user && isRental && itemUuid && <CalendarSubscribeButton kind="item" id={itemUuid} />}
+        </div>
       </div>
 
       <div className={cn('grid gap-8', hasImages ? 'md:grid-cols-2' : 'grid-cols-1')}>


### PR DESCRIPTION
## What

Adds a share action to the item detail page, next to the existing calendar subscription button.

- **Mobile:** opens the native share sheet (Web Share API) with the item name, description and link.
- **Desktop** (or anywhere the Web Share API is unavailable): copies the canonical item link to the clipboard and shows a confirmation notification. The button also flips to a green check for ~2s as immediate feedback.

The shared link is built as `${origin}/item/${item.id}` so any `#booking` hash or query string of the current URL is not shared along.

## Changes

- `frontend/src/hooks/useShare.ts` — new hook that picks the platform-appropriate behaviour (`useIsMobile` + `navigator.share` feature detection) and returns an outcome (`shared` / `dismissed` / `copied` / `error`). A dismissed share sheet is not treated as a failure; any other share error falls back to copying.
- `frontend/src/lib/clipboard.ts` — `copyToClipboard` helper using the async Clipboard API with a hidden-textarea `execCommand` fallback for insecure contexts (e.g. plain-http dev servers).
- `frontend/src/components/items/ShareButton.tsx` — Mantine `ActionIcon` + `Tooltip` with a `lucide-react` `Share2` icon, `aria-label`, and a `share-button` test id for e2e.
- `frontend/src/pages/ItemDetail.tsx` — renders the button in the header row.
- `frontend/src/contexts/LanguageContext.tsx` — `share.*` strings in English and German.

## Verification

- `npm run typecheck` — no new errors (the remaining ones are pre-existing on `main`).
- `npm run lint` — no new findings for the touched files.
- `npx prettier --check` — clean.
- `npm run build` — succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsB2nMJ5R6uxZGkCkf882p)_