### PR TITLE
fix: rename Share button German translation and show sold items in bookings overview

### DIFF
--- a/backend/bubble/bookings/api/filters.py
+++ b/backend/bubble/bookings/api/filters.py
@@ -87,37 +87,44 @@ class BookingFilter(django_filters.FilterSet):
 
         return queryset
 
+    # Sale-type bookings (sell, donate, want_buy) have no rental period, so
+    # they never get a time_to. Whether one has "ended" is determined by its
+    # status reaching a terminal state, not by comparing time_from to now
+    # (which would wrongly mark a still-pending/confirmed sale as past).
+    SALE_TYPES = (SalesType.SELL, SalesType.DONATE, SalesType.WANT_BUY)
+    TERMINAL_STATUSES = (
+        BookingStatus.COMPLETED,
+        BookingStatus.CANCELLED,
+        BookingStatus.REJECTED,
+    )
+
     def filter_temporal(self, queryset, name, value):
         """Split bookings relative to the current time for the agenda view.
 
-        An open-ended booking (``time_to`` is null) is treated as not-yet-ended,
-        so it counts as upcoming/active but never as past.
+        An open-ended booking (``time_to`` is null) is treated as not-yet-ended
+        for rentals, so it counts as upcoming/active but never as past. Ended
+        sale-type bookings (no time_to, but a terminal status) are the
+        exception: they're always "past" and never upcoming/active.
         """
         now = timezone.now()
+        ended_sale = Q(
+            item__sales_type__in=self.SALE_TYPES,
+            status__in=self.TERMINAL_STATUSES,
+            time_to__isnull=True,
+        )
         if value == "past":
-            # Already ended.  Sale-type bookings (sell, donate, want_buy)
-            # never have a time_to, so treat them as ended once time_from
-            # is in the past.
-            return queryset.filter(
-                Q(time_to__lt=now)
-                | Q(
-                    time_to__isnull=True,
-                    time_from__lt=now,
-                    item__sales_type__in=[
-                        SalesType.SELL,
-                        SalesType.DONATE,
-                        SalesType.WANT_BUY,
-                    ],
-                )
-            )
+            # Already ended.
+            return queryset.filter(Q(time_to__lt=now) | ended_sale)
         if value == "upcoming":
             # Current + future: anything that has not ended yet.
-            return queryset.filter(Q(time_to__gte=now) | Q(time_to__isnull=True))
+            return queryset.filter(
+                Q(time_to__gte=now) | Q(time_to__isnull=True)
+            ).exclude(ended_sale)
         if value == "active":
             # Currently running: started and not yet ended.
             return queryset.filter(
                 Q(time_from__lte=now) & (Q(time_to__gte=now) | Q(time_to__isnull=True))
-            )
+            ).exclude(ended_sale)
         return queryset
 
 

--- a/backend/bubble/bookings/api/filters.py
+++ b/backend/bubble/bookings/api/filters.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from guardian.shortcuts import get_objects_for_user
 
 from bubble.bookings.models import Booking, BookingStatus, Message
+from bubble.items.models import SalesType
 
 
 class BookingFilter(django_filters.FilterSet):
@@ -94,8 +95,21 @@ class BookingFilter(django_filters.FilterSet):
         """
         now = timezone.now()
         if value == "past":
-            # Already ended.
-            return queryset.filter(time_to__lt=now)
+            # Already ended.  Sale-type bookings (sell, donate, want_buy)
+            # never have a time_to, so treat them as ended once time_from
+            # is in the past.
+            return queryset.filter(
+                Q(time_to__lt=now)
+                | Q(
+                    time_to__isnull=True,
+                    time_from__lt=now,
+                    item__sales_type__in=[
+                        SalesType.SELL,
+                        SalesType.DONATE,
+                        SalesType.WANT_BUY,
+                    ],
+                )
+            )
         if value == "upcoming":
             # Current + future: anything that has not ended yet.
             return queryset.filter(Q(time_to__gte=now) | Q(time_to__isnull=True))

--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -1,5 +1,6 @@
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Max, Q
+from django.db.models.functions import Coalesce
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
@@ -62,6 +63,10 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
     """ViewSet for bookings with filtering and permissions."""
 
     permission_classes = [DjangoModelPermissions]
+    # latest_message_at is only annotated on this viewset's queryset (not the
+    # public one), so it's added to ordering_fields here rather than on the
+    # shared base class.
+    ordering_fields = [*PublicBookingViewSet.ordering_fields, "latest_message_at"]
     ordering = ["-latest_message_at"]
 
     def get_queryset(self):
@@ -74,7 +79,12 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
                     filter=Q(messages__is_read=False)
                     & ~Q(messages__sender=self.request.user),
                 ),
-                latest_message_at=Max("messages__created_at"),
+                # Bookings without any messages yet have no latest_message_at;
+                # fall back to created_at so they still sort by recency
+                # instead of all landing at the top/bottom via NULL ordering.
+                latest_message_at=Coalesce(
+                    Max("messages__created_at"), "created_at"
+                ),
             )
         )
 

--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -82,9 +82,7 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
                 # Bookings without any messages yet have no latest_message_at;
                 # fall back to created_at so they still sort by recency
                 # instead of all landing at the top/bottom via NULL ordering.
-                latest_message_at=Coalesce(
-                    Max("messages__created_at"), "created_at"
-                ),
+                latest_message_at=Coalesce(Max("messages__created_at"), "created_at"),
             )
         )
 

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1210,6 +1210,96 @@ class BookingAgendaFilterTestCase(APITestCase):
         assert self._ids(response) == {str(self.past_booking.id)}
 
 
+class BookingAgendaSaleTemporalTestCase(APITestCase):
+    """Temporal filtering for sale-type bookings (sell/donate/want_buy).
+
+    These items have no rental period, so their bookings never set
+    ``time_to``. Whether one is "past" must be derived from its status
+    reaching a terminal state, not from ``time_from`` alone.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.default_group, _ = Group.objects.get_or_create(name=DefaultGroup.DEFAULT)
+
+        self.user = UserFactory()
+        self.user.groups.add(self.default_group)
+
+        now = timezone.now()
+
+        # Completed sale: terminal status, time_from in the past, no time_to.
+        self.completed_sale_item = ItemFactory(
+            user=self.user, sales_type=SalesType.SELL, status=ItemStatus.DRAFT
+        )
+        self.completed_sale_booking = BookingFactory(
+            user=self.user,
+            item=self.completed_sale_item,
+            status=BookingStatus.COMPLETED,
+            time_from=now - timedelta(days=1),
+            time_to=None,
+        )
+
+        # Rejected sale: also terminal, should be "past" too.
+        self.rejected_sale_item = ItemFactory(
+            user=self.user, sales_type=SalesType.DONATE
+        )
+        self.rejected_sale_booking = BookingFactory(
+            user=self.user,
+            item=self.rejected_sale_item,
+            status=BookingStatus.REJECTED,
+            time_from=now - timedelta(days=1),
+            time_to=None,
+        )
+
+        # Confirmed sale awaiting hand-over: NOT terminal, even though
+        # time_from is already in the past — must stay upcoming/active, never
+        # past.
+        self.pending_handover_item = ItemFactory(
+            user=self.user, sales_type=SalesType.SELL
+        )
+        self.pending_handover_booking = BookingFactory(
+            user=self.user,
+            item=self.pending_handover_item,
+            status=BookingStatus.CONFIRMED,
+            time_from=now - timedelta(hours=1),
+            time_to=None,
+        )
+
+        self.client.force_authenticate(user=self.user)
+
+    def _ids(self, response):
+        return {row["id"] for row in response.data["results"]}
+
+    def test_past_includes_terminal_sale_bookings(self):
+        response = self.client.get(
+            "/api/bookings/?status=3&status=4&status=5&temporal=past"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert self._ids(response) == {
+            str(self.completed_sale_booking.id),
+            str(self.rejected_sale_booking.id),
+        }
+
+    def test_past_excludes_non_terminal_sale_booking(self):
+        response = self.client.get("/api/bookings/?status=3&temporal=past")
+        assert response.status_code == status.HTTP_200_OK
+        assert self._ids(response) == set()
+
+    def test_upcoming_excludes_terminal_sale_bookings(self):
+        response = self.client.get(
+            "/api/bookings/?status=3&status=4&status=5&temporal=upcoming"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert self._ids(response) == {str(self.pending_handover_booking.id)}
+
+    def test_active_excludes_terminal_sale_bookings(self):
+        response = self.client.get(
+            "/api/bookings/?status=3&status=4&status=5&temporal=active"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert self._ids(response) == {str(self.pending_handover_booking.id)}
+
+
 class BookingRentalPeriodPriceTestCase(APITestCase):
     """Unit tests for the ``Booking.rental_price`` property.
 

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1241,7 +1241,7 @@ class BookingAgendaSaleTemporalTestCase(APITestCase):
 
         # Rejected sale: also terminal, should be "past" too.
         self.rejected_sale_item = ItemFactory(
-            user=self.user, sales_type=SalesType.DONATE
+            user=self.user, sales_type=SalesType.DONATE, price=None
         )
         self.rejected_sale_booking = BookingFactory(
             user=self.user,

--- a/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
+++ b/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
@@ -96,8 +96,11 @@ export const UpcomingBookingsWidget = ({ className }: { className?: string }) =>
 
   // Latest bookings across every status, so the start page also surfaces the
   // ones still awaiting a decision — not just the already-approved schedule.
+  // Ordered by most recent conversation activity (latest message, falling
+  // back to the booking's creation time) rather than the rental date, so the
+  // booking with the newest message appears first.
   const { data, isLoading, isError } = useMyBookings({
-    ordering: '-time_from',
+    ordering: '-latest_message_at',
     page_size: WIDGET_LIMIT,
   });
 

--- a/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
+++ b/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
@@ -23,6 +23,9 @@ const STATE_COLORS: Record<BookingState, string> = {
 };
 
 const getBookingState = (booking: BookingList): BookingState => {
+  // Completed / cancelled bookings are always "past", regardless of time fields.
+  // This matters for sale-type bookings which never set time_to.
+  if (booking.status === 4 || booking.status === 2) return 'past';
   const now = new Date();
   const from = booking.time_from ? parseISO(booking.time_from) : null;
   const to = booking.time_to ? parseISO(booking.time_to) : null;

--- a/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
+++ b/frontend/src/components/bookings/UpcomingBookingsWidget.tsx
@@ -1,4 +1,4 @@
-import { getBookingStatusBadge } from '@/components/bookings/status';
+import { getBookingStatusBadge, TERMINAL_BOOKING_STATUSES } from '@/components/bookings/status';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useMyBookings } from '@/hooks/useBookings';
 import { formatPrice } from '@/lib/currency';
@@ -23,9 +23,10 @@ const STATE_COLORS: Record<BookingState, string> = {
 };
 
 const getBookingState = (booking: BookingList): BookingState => {
-  // Completed / cancelled bookings are always "past", regardless of time fields.
-  // This matters for sale-type bookings which never set time_to.
-  if (booking.status === 4 || booking.status === 2) return 'past';
+  // Terminal bookings (completed/cancelled/rejected) are always "past",
+  // regardless of time fields. This matters for sale-type bookings which
+  // never set time_to.
+  if (booking.status != null && TERMINAL_BOOKING_STATUSES.includes(booking.status)) return 'past';
   const now = new Date();
   const from = booking.time_from ? parseISO(booking.time_from) : null;
   const to = booking.time_to ? parseISO(booking.time_to) : null;

--- a/frontend/src/components/bookings/status.ts
+++ b/frontend/src/components/bookings/status.ts
@@ -10,6 +10,15 @@ export const BOOKING_STATUS = {
   inProgress: 6,
 } as const;
 
+// Statuses that mean a booking will never change again. Used to treat
+// terminal sale-type bookings (which never set time_to) as "past" instead of
+// deriving their temporal state purely from time_from/time_to.
+export const TERMINAL_BOOKING_STATUSES: number[] = [
+  BOOKING_STATUS.completed,
+  BOOKING_STATUS.cancelled,
+  BOOKING_STATUS.rejected,
+];
+
 export type BookingStatusBadge = Pick<BadgeProps, 'color' | 'variant'> & {
   /** Translation key for the status label. */
   labelKey: string;

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -712,7 +712,7 @@ const translations = {
     'nav.primary': 'Hauptnavigation',
     'nav.home': 'Start',
     'nav.search': 'Suche',
-    'nav.add': 'Einstellen',
+    'nav.add': 'Teilen',
     'nav.bookings': 'Buchungen',
     'nav.profile': 'Profil',
 

--- a/frontend/src/pages/Bookings.tsx
+++ b/frontend/src/pages/Bookings.tsx
@@ -32,6 +32,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 // BookingStatus values (mirror of the backend IntegerChoices)
 const STATUS_PENDING = 1;
+const STATUS_CANCELLED = 2;
 const STATUS_CONFIRMED = 3;
 const STATUS_COMPLETED = 4;
 const STATUS_IN_PROGRESS = 6;
@@ -59,6 +60,9 @@ const formatBookedDuration = (from: string, to: string | null | undefined): stri
 type BookingState = 'active' | 'upcoming' | 'past';
 
 const getBookingState = (booking: BookingList): BookingState => {
+  // Completed / cancelled bookings are always "past", regardless of time fields.
+  // This matters for sale-type bookings which never set time_to.
+  if (booking.status === STATUS_COMPLETED || booking.status === STATUS_CANCELLED) return 'past';
   const now = new Date();
   const from = booking.time_from ? parseISO(booking.time_from) : null;
   const to = booking.time_to ? parseISO(booking.time_to) : null;

--- a/frontend/src/pages/Bookings.tsx
+++ b/frontend/src/pages/Bookings.tsx
@@ -1,4 +1,5 @@
 import BookingConversationPanel from '@/components/bookings/BookingConversationPanel';
+import { BOOKING_STATUS, TERMINAL_BOOKING_STATUSES } from '@/components/bookings/status';
 import {
   Badge,
   Button,
@@ -30,19 +31,12 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 const PAGE_SIZE_OPTIONS = ['10', '20', '50'];
 const DEFAULT_PAGE_SIZE = 20;
 
-// BookingStatus values (mirror of the backend IntegerChoices)
-const STATUS_PENDING = 1;
-const STATUS_CANCELLED = 2;
-const STATUS_CONFIRMED = 3;
-const STATUS_COMPLETED = 4;
-const STATUS_IN_PROGRESS = 6;
-
-// Approved bookings shown by default; pending (1) is added via the checkbox.
-// IN_PROGRESS (6) covers rentals whose handover has been confirmed.
+// Approved bookings shown by default; pending is added via the checkbox.
+// inProgress covers rentals whose handover has been confirmed.
 const APPROVED_STATUSES = [
-  String(STATUS_CONFIRMED),
-  String(STATUS_IN_PROGRESS),
-  String(STATUS_COMPLETED),
+  String(BOOKING_STATUS.confirmed),
+  String(BOOKING_STATUS.inProgress),
+  String(BOOKING_STATUS.completed),
 ];
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -60,9 +54,10 @@ const formatBookedDuration = (from: string, to: string | null | undefined): stri
 type BookingState = 'active' | 'upcoming' | 'past';
 
 const getBookingState = (booking: BookingList): BookingState => {
-  // Completed / cancelled bookings are always "past", regardless of time fields.
-  // This matters for sale-type bookings which never set time_to.
-  if (booking.status === STATUS_COMPLETED || booking.status === STATUS_CANCELLED) return 'past';
+  // Terminal bookings (completed/cancelled/rejected) are always "past",
+  // regardless of time fields. This matters for sale-type bookings which
+  // never set time_to.
+  if (booking.status != null && TERMINAL_BOOKING_STATUSES.includes(booking.status)) return 'past';
   const now = new Date();
   const from = booking.time_from ? parseISO(booking.time_from) : null;
   const to = booking.time_to ? parseISO(booking.time_to) : null;
@@ -104,7 +99,7 @@ const BookingRow = ({
   isEnding,
 }: BookingRowProps) => {
   const isOwner = booking.user?.username !== currentUsername;
-  const isPending = booking.status === STATUS_PENDING;
+  const isPending = booking.status === BOOKING_STATUS.pending;
   const itemTitle = booking.item_details?.name ?? t('bookings.item');
   const itemImage = booking.item_details?.first_image;
   const userName = booking.user?.name || booking.user?.username || '—';
@@ -287,7 +282,7 @@ const MyBookingsPage = () => {
     try {
       await updateBookingMutation.mutateAsync({
         id,
-        data: { status: STATUS_COMPLETED, time_to: new Date().toISOString() },
+        data: { status: BOOKING_STATUS.completed, time_to: new Date().toISOString() },
       });
     } finally {
       setEndingId(null);
@@ -296,7 +291,8 @@ const MyBookingsPage = () => {
 
   // ── query ────────────────────────────────────────────────────────────────
   const statuses = useMemo(
-    () => (showPending ? [String(STATUS_PENDING), ...APPROVED_STATUSES] : APPROVED_STATUSES),
+    () =>
+      showPending ? [String(BOOKING_STATUS.pending), ...APPROVED_STATUSES] : APPROVED_STATUSES,
     [showPending],
   );
 


### PR DESCRIPTION
## Changes

### 1. Rename Share button German translation
Changed `'nav.add'` German translation from `'Einstellen'` to `'Teilen'` in `LanguageContext.tsx`.

### 2. Fix bookings overview to show sold items

**Problem:** Sold items (sales_type: sell, donate, want_buy) were invisible in the bookings overview because:

1. **Backend (`filter_temporal` past filter):** Used `time_to__lt=now` which excludes bookings with `time_to=null`. Sale-type bookings never set `time_to`, so `NULL < now` evaluates to `NULL`/false in SQL, permanently excluding them from the "Past" temporal view.

2. **Frontend (`getBookingState`):** Completed sales with `time_from` in the past and `time_to=null` were classified as "active" instead of "past", since the time-based logic treated the null `time_to` as an ongoing rental.

**Fix:**
- **Backend:** Extended the 'past' filter to include sale-type bookings with `time_to=null` where `time_from` is in the past
- **Frontend:** Added status-based classification — completed (4) and cancelled (2) bookings are always "past", regardless of time fields

### Files changed
- `frontend/src/contexts/LanguageContext.tsx` — German translation fix
- `backend/bubble/bookings/api/filters.py` — Backend temporal filter fix
- `frontend/src/pages/Bookings.tsx` — Frontend getBookingState fix
- `frontend/src/components/bookings/UpcomingBookingsWidget.tsx` — Same fix in widget