### PR TITLE
feat(auth): auto-redirect to single social provider when password login disabled

### DIFF
--- a/frontend/src/components/auth/LoginWithSocialButton.tsx
+++ b/frontend/src/components/auth/LoginWithSocialButton.tsx
@@ -1,5 +1,4 @@
-import { getCSRFToken } from '@/lib/utils';
-import { client } from '@/services/django/client.gen';
+import { redirectToSocialProvider } from '@/lib/utils';
 import { Button } from '@mantine/core';
 import { useState } from 'react';
 
@@ -14,27 +13,7 @@ export default function LoginWithSocialButton({ name, id }: LoginWithSocialButto
   function handleClick() {
     if (loading) return;
     setLoading(true);
-
-    const form = document.createElement('form');
-    form.style.display = 'none';
-    form.method = 'POST';
-    form.action = `${client.getConfig().baseUrl}/api/_allauth/browser/v1/auth/provider/redirect`;
-    const data = {
-      provider: id,
-      callback_url: `${window.location.origin}/`,
-      csrfmiddlewaretoken: getCSRFToken() || '',
-      process: 'login',
-    };
-
-    Object.entries(data).forEach(([k, v]) => {
-      const input = document.createElement('input');
-      input.name = k;
-      input.value = v as string;
-      form.appendChild(input);
-    });
-    document.body.appendChild(form);
-    // Submit will usually navigate away; disable protects against double-clicks
-    form.submit();
+    redirectToSocialProvider(id);
   }
 
   return (

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -9,7 +9,7 @@ interface LanguageContextType {
   /** Apply a language coming from an external source (e.g. profile API)
    *  without triggering a save-back. */
   syncLanguage: (lang: Language) => void;
-  t: (key: string) => string;
+  t: (key: string, params?: Record<string, string | number>) => string;
 }
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
@@ -93,6 +93,7 @@ const translations = {
     'auth.loggedInAs': 'Logged in successfully as',
     'auth.loginFailed': 'Login failed. Please check your credentials.',
     'auth.unexpectedError': 'An unexpected error occurred. Please try again.',
+    'auth.redirectingToProvider': 'Redirecting to {{provider}}...',
 
     // Index Page
     'index.itemsFound': '{count} items found',
@@ -775,6 +776,7 @@ const translations = {
     'auth.loggedInAs': 'Erfolgreich eingeloggt als',
     'auth.loginFailed': 'Anmeldung fehlgeschlagen. Bitte überprüfe deine Zugangsdaten.',
     'auth.unexpectedError': 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.',
+    'auth.redirectingToProvider': 'Weiterleitung zu {{provider}}...',
 
     // Index Page
     'index.itemsFound': '{count} Artikel gefunden',
@@ -1427,8 +1429,14 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const t = useCallback(
-    (key: string): string => {
-      return translations[language][key as keyof (typeof translations)['en']] || key;
+    (key: string, params?: Record<string, string | number>): string => {
+      let value = translations[language][key as keyof (typeof translations)['en']] || key;
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          value = value.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+        }
+      }
+      return value;
     },
     [language],
   );

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { client } from '@/services/django/client.gen';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -22,4 +23,27 @@ export function getCookie(name: string): string | null {
 }
 export function getCSRFToken() {
   return getCookie('csrftoken');
+}
+
+// Submits a hidden form that triggers an allauth social provider login redirect.
+export function redirectToSocialProvider(providerId: string) {
+  const form = document.createElement('form');
+  form.style.display = 'none';
+  form.method = 'POST';
+  form.action = `${client.getConfig().baseUrl}/api/_allauth/browser/v1/auth/provider/redirect`;
+  const data = {
+    provider: providerId,
+    callback_url: `${window.location.origin}/`,
+    csrfmiddlewaretoken: getCSRFToken() || '',
+    process: 'login',
+  };
+
+  Object.entries(data).forEach(([k, v]) => {
+    const input = document.createElement('input');
+    input.name = k;
+    input.value = v as string;
+    form.appendChild(input);
+  });
+  document.body.appendChild(form);
+  form.submit();
 }

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -2,11 +2,13 @@ import LoginWithSocialButton from '@/components/auth/LoginWithSocialButton';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
+import { useAppConfig } from '@/hooks/useAppConfig';
 import { authAPI, LoginCredentials } from '@/services/custom/auth';
+import { redirectToSocialProvider } from '@/lib/utils';
 import { client } from '@/services/django/client.gen';
 import { Alert, Button, Card, Divider, PasswordInput, Text, TextInput, Title } from '@mantine/core';
 import { Eye, EyeOff, Loader } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface AuthConfig {
@@ -29,6 +31,10 @@ const Auth = () => {
   const { toast } = useToast();
   const { t } = useLanguage();
   const { refreshAuth } = useAuth();
+  const { requireLogin } = useAppConfig();
+
+  // Guards the auto-redirect so it only fires once.
+  const autoRedirectedRef = useRef(false);
 
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);
@@ -37,6 +43,7 @@ const Auth = () => {
     username: '',
     password: '',
   });
+  const [redirectingTo, setRedirectingTo] = useState<string | null>(null);
 
   // Fetch CSRF token on component mount
   useEffect(() => {
@@ -54,6 +61,22 @@ const Auth = () => {
     initializeCSRF();
   }, []);
 
+  // When anonymous access is disabled and exactly one social provider is
+  // configured with no username/password login, skip the login screen and
+  // forward straight to the provider. Otherwise users would only ever see a
+  // single "Login with X" button that does the same thing.
+  const maybeAutoRedirect = (config: AuthConfig | null) => {
+    if (!requireLogin || autoRedirectedRef.current) return;
+    const providers = config?.data?.socialaccount?.providers ?? [];
+    const loginMethods = config?.data?.account?.login_methods ?? [];
+
+    if (providers.length === 1 && loginMethods.length === 0) {
+      autoRedirectedRef.current = true;
+      setRedirectingTo(providers[0].name);
+      redirectToSocialProvider(providers[0].id);
+    }
+  };
+
   // Fetch auth config to determine which login methods and social providers are available
   useEffect(() => {
     const fetchConfig = async () => {
@@ -65,6 +88,7 @@ const Auth = () => {
         }
         const json = await res.json();
         setAuthConfig(json);
+        maybeAutoRedirect(json);
       } catch (err) {
         console.error('Failed to fetch auth config:', err);
         setAuthConfig(null);
@@ -74,6 +98,8 @@ const Auth = () => {
     };
 
     fetchConfig();
+    // requireLogin is resolved by the time this screen renders (App gates on it)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -129,7 +155,11 @@ const Auth = () => {
           <div className="space-y-6 mt-6">
             {/* Social Login Button */}
             <div className="text-center">
-              {loadingConfig ? (
+              {redirectingTo ? (
+                <Text size="sm" c="dimmed">
+                  {t('auth.redirectingToProvider', { provider: redirectingTo })}
+                </Text>
+              ) : loadingConfig ? (
                 <Text size="sm" c="dimmed">
                   {t('common.loading')}
                 </Text>


### PR DESCRIPTION
## Summary
- When `REQUIRE_LOGIN` (anonymous access) is enabled, a single social provider is configured, and username/password login is unavailable, the Auth page now forwards straight to that provider's login flow instead of rendering a redundant "Login with X" button.
- Extracted the provider-redirect form submission into a shared `redirectToSocialProvider` helper in `src/lib/utils.ts`, used by both the Auth auto-redirect and `LoginWithSocialButton`.
- Added a "Redirecting to {provider}…" indicator (EN/DE) while the redirect is in flight, plus lightweight `{{param}}` interpolation in the `t` translation function.

## Test plan
- Frontend `typecheck` and `lint` pass locally.
- Verified the auto-redirect only triggers when `requireLogin` is true, exactly one provider is present, and `login_methods` is empty.

🤖 Generated with [opencode](https://opencode.ai)