### PR TITLE
fix: rename menu labels to "my" phrasing and drop duplicate mobile bookings entry

### DIFF
--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -21,7 +21,7 @@ const translations = {
     'header.shareItem': 'Share',
     'header.signIn': 'Sign In',
     'header.myProfile': 'Profile',
-    'header.items': 'Items',
+    'header.items': 'My Items',
     'header.signOut': 'Sign Out',
     'header.theme': 'Theme',
     'header.light': 'Light',
@@ -40,7 +40,7 @@ const translations = {
     'account.settings': 'Profile settings',
 
     // Mobile start page
-    'home.bookingsTitle': 'Your bookings',
+    'home.bookingsTitle': 'My bookings',
     'home.bookingsSubtitle': 'Latest',
     'home.noBookings': 'No bookings yet',
     'header.browse': 'Browse',
@@ -600,7 +600,7 @@ const translations = {
     'scanner.detected': 'Detected',
 
     // Collections
-    'collections.title': 'Collections',
+    'collections.title': 'My Collections',
     'collections.myCollections': 'My Collections',
     'collections.newCollection': 'New Collection',
     'collections.newCollectionShort': 'New',
@@ -704,7 +704,7 @@ const translations = {
     'header.shareItem': 'Teilen',
     'header.signIn': 'Anmelden',
     'header.myProfile': 'Profil',
-    'header.items': 'Artikel',
+    'header.items': 'Meine Artikel',
     'header.signOut': 'Abmelden',
     'header.theme': 'Design',
     'header.light': 'Hell',
@@ -723,7 +723,7 @@ const translations = {
     'account.settings': 'Profileinstellungen',
 
     // Mobile start page
-    'home.bookingsTitle': 'Deine Buchungen',
+    'home.bookingsTitle': 'Meine Buchungen',
     'home.bookingsSubtitle': 'Neueste',
     'home.noBookings': 'Noch keine Buchungen',
     'header.browse': 'Entdecken',
@@ -1295,7 +1295,7 @@ const translations = {
     'scanner.detected': 'Erkannt',
 
     // Collections
-    'collections.title': 'Sammlungen',
+    'collections.title': 'Meine Sammlungen',
     'collections.myCollections': 'Meine Sammlungen',
     'collections.newCollection': 'Neue Sammlung',
     'collections.newCollectionShort': 'Neu',

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1,7 +1,7 @@
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useAuth } from '@/hooks/useAuth';
 import { Avatar, Button, Card, Divider, Group, NavLink, Stack, Text } from '@mantine/core';
-import { BookMarked, CalendarCheck, ChevronRight, Library, LogOut, Settings } from 'lucide-react';
+import { BookMarked, ChevronRight, Library, LogOut, Settings } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Fragment } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -16,7 +16,6 @@ interface HubEntry {
 // menu; on mobile that menu is hidden, so this hub is their entry point.
 const ENTRIES: HubEntry[] = [
   { labelKey: 'header.items', icon: Library, to: '/my-items' },
-  { labelKey: 'header.bookings', icon: CalendarCheck, to: '/bookings' },
   { labelKey: 'collections.title', icon: BookMarked, to: '/collections' },
   { labelKey: 'account.settings', icon: Settings, to: '/profile' },
 ];


### PR DESCRIPTION
## Summary
- Rename "Your bookings" → "My bookings" (en + de)
- Rename "Items" → "My Items" in menus (en + de)
- Rename "Collections" → "My Collections" in menus (en + de)
- Remove the "Bookings" entry from the mobile profile hub (`Account.tsx`) since it is already present in the bottom navigation

## Test plan
- [x] `npm run typecheck` passes
- [x] `prettier --check` passes on changed files
- [x] German translations updated alongside English