### PR TITLE
feat: prefill rocketchat/matrix profile fields when configured via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Users then choose, per channel, which events they want:
 
 The phone number can be filled in manually on the profile, or is pre-populated from the `phone_number` claim of your OIDC provider when available (the `phone` scope is requested automatically).
 
+RocketChat always addresses a user by their bubble username, so it needs no separate field — once `APPRISE_ROCKETCHAT_URL` is configured, the RocketChat channel and its notification options appear automatically. Matrix works the same way: once `APPRISE_MATRIX_URL` is configured, a user's empty Matrix ID is prefilled with their bubble username so the Matrix channel becomes available immediately (they can still edit it to their real `@user:server` address).
+
 # Federation (ActivityPub)
 
 Bubble supports ActivityPub federation, allowing items, bookings, and messages to flow between Bubble instances and interact with the broader fediverse (Mastodon, etc.).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ These can be set via environment variables or edited at runtime in the Django ad
 A channel only appears in a user's profile once it is **both**:
 
 1. configured on the backend (the Apprise URL above is set), and
-2. addressable for that user (the matching profile field is filled in — RocketChat username, Signal phone number, Matrix ID or email).
+2. addressable for that user (RocketChat and email use the bubble username/account email automatically; Signal needs a phone number on the profile; Matrix needs a Matrix ID, editable right in the Notifications section).
 
 Users then choose, per channel, which events they want:
 
@@ -51,7 +51,7 @@ Users then choose, per channel, which events they want:
 
 The phone number can be filled in manually on the profile, or is pre-populated from the `phone_number` claim of your OIDC provider when available (the `phone` scope is requested automatically).
 
-RocketChat always addresses a user by their bubble username, so it needs no separate field — once `APPRISE_ROCKETCHAT_URL` is configured, the RocketChat channel and its notification options appear automatically. Matrix works the same way: once `APPRISE_MATRIX_URL` is configured, a user's empty Matrix ID is prefilled with their bubble username so the Matrix channel becomes available immediately (they can still edit it to their real `@user:server` address).
+RocketChat and email always address a user by their bubble username/account email, so they need no separate field — once `APPRISE_ROCKETCHAT_URL`/`APPRISE_MAILTOS_URL` is configured, those channels and their notification options appear automatically (email notifications, like every other channel, start out **disabled** until the user opts in). Matrix works similarly but needs a per-user Matrix ID: once `APPRISE_MATRIX_URL` is configured, the Matrix panel appears in the **Notifications** section of the profile with an editable Matrix ID field, prefilled with the user's bubble username so the channel becomes available immediately (they can still edit it to their real `@user:server` address).
 
 # Federation (ActivityPub)
 

--- a/backend/bubble/notifications/api/serializers.py
+++ b/backend/bubble/notifications/api/serializers.py
@@ -40,12 +40,15 @@ def _target_field(provider: str) -> str:
 class NotificationPreferenceMeSerializer(serializers.Serializer):
     """Flat serializer for GET/PATCH /api/notification-preferences/me/.
 
-    For every provider (RocketChat, Signal, Email) it exposes:
+    For every provider (webpush, RocketChat, Signal, Matrix, email) it
+    exposes:
 
-    * ``<provider>_configured`` (read-only): the channel has an Apprise URL
-      template configured on the backend (Constance/env), regardless of
-      whether this particular user is reachable on it yet. The frontend uses
-      this to decide whether to prefill a user's address for a channel.
+    * ``<provider>_configured`` (read-only): the channel is set up on the
+      backend, independent of whether this particular user is reachable on
+      it yet. For the Apprise-backed channels (RocketChat, Signal, Matrix,
+      email) that means an Apprise URL template is configured (Constance/env);
+      for ``webpush`` it means a VAPID keypair is configured. The frontend
+      uses this to decide whether to prefill a user's address for a channel.
     * ``<provider>_available`` (read-only): the channel is configured on the
       backend *and* the user has filled in the field it needs to reach them.
       For ``webpush`` there is no such field — availability means at least one

--- a/backend/bubble/notifications/api/serializers.py
+++ b/backend/bubble/notifications/api/serializers.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
-from bubble.notifications.channels import is_channel_available, resolve_target
+from bubble.notifications.channels import (
+    is_backend_configured,
+    is_channel_available,
+    resolve_target,
+)
 from bubble.notifications.models import EVENT_GROUPS, NotificationPreference
 
 ProviderType = NotificationPreference.ProviderType
@@ -21,6 +25,10 @@ def _toggle_field(provider: str, group: str) -> str:
     return f"{provider}_{group}"
 
 
+def _configured_field(provider: str) -> str:
+    return f"{provider}_configured"
+
+
 def _available_field(provider: str) -> str:
     return f"{provider}_available"
 
@@ -34,6 +42,10 @@ class NotificationPreferenceMeSerializer(serializers.Serializer):
 
     For every provider (RocketChat, Signal, Email) it exposes:
 
+    * ``<provider>_configured`` (read-only): the channel has an Apprise URL
+      template configured on the backend (Constance/env), regardless of
+      whether this particular user is reachable on it yet. The frontend uses
+      this to decide whether to prefill a user's address for a channel.
     * ``<provider>_available`` (read-only): the channel is configured on the
       backend *and* the user has filled in the field it needs to reach them.
       For ``webpush`` there is no such field — availability means at least one
@@ -48,6 +60,9 @@ class NotificationPreferenceMeSerializer(serializers.Serializer):
     def get_fields(self):
         fields = super().get_fields()
         for provider in PROVIDERS:
+            fields[_configured_field(provider)] = serializers.BooleanField(
+                read_only=True
+            )
             fields[_available_field(provider)] = serializers.BooleanField(
                 read_only=True
             )
@@ -66,6 +81,7 @@ class NotificationPreferenceMeSerializer(serializers.Serializer):
 
         data: dict[str, object] = {}
         for provider in PROVIDERS:
+            data[_configured_field(provider)] = is_backend_configured(provider)
             data[_available_field(provider)] = is_channel_available(provider, user)
             data[_target_field(provider)] = resolve_target(provider, user)
             for group, events in EVENT_GROUPS.items():

--- a/backend/bubble/notifications/tests/test_serializers.py
+++ b/backend/bubble/notifications/tests/test_serializers.py
@@ -27,14 +27,31 @@ def test_to_representation_reports_availability_and_toggles() -> None:
 
     data = NotificationPreferenceMeSerializer().to_representation(user)
 
+    assert data["rocketchat_configured"] is True
     assert data["rocketchat_available"] is True
     assert data["rocketchat_target"] == "alice"
     # messages group is on only when *all* underlying events are enabled
     assert data["rocketchat_messages"] is True
     assert data["rocketchat_new_item"] is False
     # signal/email are not configured → unavailable
+    assert data["signal_configured"] is False
     assert data["signal_available"] is False
+    assert data["email_configured"] is False
     assert data["email_available"] is False
+
+
+@pytest.mark.django_db
+@override_config(APPRISE_MATRIX_URL="matrixs://user:pass@matrix.example.com/{target}")
+def test_configured_is_true_even_without_a_user_target() -> None:
+    # "configured" reflects backend setup only, unlike "available" which also
+    # requires the user to have filled in their address for the channel.
+    user = UserFactory(username="alice")
+
+    data = NotificationPreferenceMeSerializer().to_representation(user)
+
+    assert data["matrix_configured"] is True
+    assert data["matrix_available"] is False
+    assert data["matrix_target"] == ""
 
 
 @pytest.mark.django_db

--- a/backend/bubble/notifications/tests/test_serializers.py
+++ b/backend/bubble/notifications/tests/test_serializers.py
@@ -55,6 +55,22 @@ def test_configured_is_true_even_without_a_user_target() -> None:
 
 
 @pytest.mark.django_db
+@override_config(APPRISE_MAILTOS_URL="mailtos://user:pass@smtp.example.com?to={target}")
+def test_email_is_available_but_disabled_by_default() -> None:
+    # Unlike RocketChat, email gets no default-enabled preference row on
+    # signup — it only ever turns on when the user opts in themselves.
+    user = UserFactory(username="alice", email="alice@example.com")
+
+    data = NotificationPreferenceMeSerializer().to_representation(user)
+
+    assert data["email_configured"] is True
+    assert data["email_available"] is True
+    assert data["email_target"] == "alice@example.com"
+    assert data["email_messages"] is False
+    assert data["email_new_item"] is False
+
+
+@pytest.mark.django_db
 @override_config(APPRISE_ROCKETCHAT_URL=ROCKET_URL)
 def test_messages_toggle_writes_message_and_booking_events() -> None:
     user = UserFactory(username="alice")

--- a/frontend/src/components/profile/NotificationSettings.tsx
+++ b/frontend/src/components/profile/NotificationSettings.tsx
@@ -1,13 +1,18 @@
-import { Card, Checkbox, Paper, Stack, Text, Title } from '@mantine/core';
-import { Loader2 } from 'lucide-react';
+import { Card, Checkbox, Paper, Stack, Text, TextInput, Title } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { Check, Loader2 } from 'lucide-react';
+import React from 'react';
 import { PushNotificationSettings } from '@/components/profile/PushNotificationSettings';
 import { useLanguage } from '@/contexts/LanguageContext';
 import {
   useNotificationPreferences,
   useUpdateNotificationPreferences,
 } from '@/hooks/useNotificationPreferences';
+import { useProfile } from '@/hooks/useProfile';
+import { useProfileFieldAutoSave } from '@/hooks/useProfileFieldAutoSave';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import type { NotificationPreferenceMe, PatchedNotificationPreferenceMe } from '@/services/django';
+import { useQueryClient } from '@tanstack/react-query';
 
 // `webpush` is deliberately absent: it needs a per-device grant, so
 // PushNotificationSettings renders it instead of the generic row below.
@@ -28,15 +33,89 @@ export const NotificationSettings = () => {
   const { data: prefs, isLoading } = useNotificationPreferences();
   const updatePrefs = useUpdateNotificationPreferences();
   const { available: pushAvailable } = usePushNotifications();
+  const { data: profile } = useProfile();
+  const { fieldStates, saveField } = useProfileFieldAutoSave();
+  const queryClient = useQueryClient();
+  const hasPrefilledMatrixId = React.useRef(false);
+  const matrixIdForm = useForm({ initialValues: { matrix_id: '' } });
+
+  React.useEffect(() => {
+    if (profile) matrixIdForm.setValues({ matrix_id: profile.matrix_id ?? '' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [profile]);
 
   const isAvailable = (provider: Provider) =>
     prefs?.[`${provider}_available` as keyof NotificationPreferenceMe] === true;
 
-  const availableProviders = PROVIDERS.filter(p => isAvailable(p.id));
+  const isConfigured = (provider: Provider) =>
+    prefs?.[`${provider}_configured` as keyof NotificationPreferenceMe] === true;
+
+  // Every other channel is only ever shown once it's already reachable
+  // (its target field is filled in), so its panel doubles as a status
+  // display. Matrix is the exception: its ID field now lives inside this
+  // panel, so the panel has to appear as soon as Matrix is configured on the
+  // backend — otherwise there'd be nowhere to type the ID in the first place.
+  const visibleProviders = PROVIDERS.filter(p =>
+    p.id === 'matrix' ? isConfigured(p.id) : isAvailable(p.id),
+  );
 
   const toggle = (field: ToggleField, checked: boolean) => {
     const payload: PatchedNotificationPreferenceMe = { [field]: checked };
     updatePrefs.mutate(payload);
+  };
+
+  // Saving the Matrix ID changes matrix_available/matrix_target, so refresh
+  // notification preferences afterwards instead of waiting for a reload.
+  const saveMatrixId = React.useCallback(
+    async (value: string): Promise<boolean> => {
+      const success = await saveField('matrix_id', value);
+      queryClient.invalidateQueries({
+        queryKey: ['notification-preferences', profile?.username],
+      });
+      return success;
+    },
+    [saveField, queryClient, profile?.username],
+  );
+
+  // When Matrix notifications are configured on the backend but this user has
+  // no Matrix ID yet, prefill it with their bubble username (same as
+  // RocketChat, which always addresses users by their bubble username) so the
+  // Matrix notification options work without requiring manual setup.
+  React.useEffect(() => {
+    if (hasPrefilledMatrixId.current) return;
+    if (!profile || !prefs) return;
+    if (!prefs.matrix_configured) return;
+    if (profile.matrix_id || !profile.username) return;
+
+    // Set the ref up front so a re-render during the save can't trigger a
+    // second attempt.
+    hasPrefilledMatrixId.current = true;
+    const username = profile.username;
+    matrixIdForm.setFieldValue('matrix_id', username);
+    saveMatrixId(username).then(success => {
+      if (!success) {
+        // Roll back so the form doesn't show an unpersisted value, and clear
+        // the ref so the next profile/prefs refetch can retry.
+        hasPrefilledMatrixId.current = false;
+        matrixIdForm.setFieldValue('matrix_id', '');
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [profile, prefs]);
+
+  const matrixIdBorderClass = () => {
+    const status = fieldStates.matrix_id?.status;
+    if (status === 'success') return 'border-green-500 focus-visible:ring-green-500';
+    if (status === 'error') return 'border-destructive focus-visible:ring-destructive';
+    return '';
+  };
+
+  const matrixIdStatusIcon = () => {
+    const status = fieldStates.matrix_id?.status;
+    if (status === 'saving')
+      return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+    if (status === 'success') return <Check className="h-4 w-4 text-green-500" />;
+    return null;
   };
 
   return (
@@ -50,38 +129,52 @@ export const NotificationSettings = () => {
         <div className="flex justify-center py-4">
           <Loader2 className="h-6 w-6 animate-spin" />
         </div>
-      ) : availableProviders.length === 0 && !pushAvailable ? (
+      ) : visibleProviders.length === 0 && !pushAvailable ? (
         <Text size="sm" c="dimmed">
           {t('profile.notificationsUnavailable')}
         </Text>
       ) : (
         <Stack gap="lg">
           <PushNotificationSettings />
-          {availableProviders.map(provider => {
+          {visibleProviders.map(provider => {
             const target = prefs?.[`${provider.id}_target` as keyof NotificationPreferenceMe] as
               string | undefined;
             const messagesField = `${provider.id}_messages` as ToggleField;
             const newItemField = `${provider.id}_new_item` as ToggleField;
+            const isMatrix = provider.id === 'matrix';
 
             return (
               <Paper key={provider.id} withBorder radius="md" p="md">
                 <Text fw={600}>{t(provider.labelKey)}</Text>
-                {target && (
-                  <Text size="xs" c="dimmed" className="mb-3">
-                    {t('profile.channelTarget')}: {target}
-                  </Text>
+                {isMatrix ? (
+                  <TextInput
+                    className="mt-2 mb-3"
+                    label={t('profile.matrixId')}
+                    placeholder="@alice:matrix.org"
+                    description={t('profile.matrixIdDesc')}
+                    classNames={{ input: matrixIdBorderClass() }}
+                    rightSection={matrixIdStatusIcon()}
+                    {...matrixIdForm.getInputProps('matrix_id')}
+                    onBlur={() => saveMatrixId(matrixIdForm.getValues().matrix_id)}
+                  />
+                ) : (
+                  target && (
+                    <Text size="xs" c="dimmed" className="mb-3">
+                      {t('profile.channelTarget')}: {target}
+                    </Text>
+                  )
                 )}
                 <Stack gap="sm" className="mt-2">
                   <Checkbox
                     checked={prefs?.[messagesField] === true}
-                    disabled={updatePrefs.isPending}
+                    disabled={updatePrefs.isPending || !target}
                     onChange={event => toggle(messagesField, event.currentTarget.checked)}
                     label={t('profile.notifyMessages')}
                     description={t('profile.notifyMessagesDesc')}
                   />
                   <Checkbox
                     checked={prefs?.[newItemField] === true}
-                    disabled={updatePrefs.isPending}
+                    disabled={updatePrefs.isPending || !target}
                     onChange={event => toggle(newItemField, event.currentTarget.checked)}
                     label={t('profile.notifyNewItem')}
                     description={t('profile.notifyNewItemDesc')}

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -32,11 +32,12 @@ export const ProfileForm = () => {
   // those fields is saved — otherwise the Notifications card would keep
   // showing its previous, now-stale set of channels until the next reload.
   const saveFieldAndRefreshNotifications = React.useCallback(
-    async (fieldName: string, value: unknown) => {
-      await saveField(fieldName, value);
+    async (fieldName: string, value: unknown): Promise<boolean> => {
+      const success = await saveField(fieldName, value);
       queryClient.invalidateQueries({
         queryKey: ['notification-preferences', profile?.username],
       });
+      return success;
     },
     [saveField, queryClient, profile?.username],
   );
@@ -71,9 +72,19 @@ export const ProfileForm = () => {
     if (!notificationPrefs.matrix_configured) return;
     if (profile.matrix_id || !profile.username) return;
 
+    // Set the ref up front so a re-render during the save (e.g. from the
+    // optimistic form update below) can't trigger a second attempt.
     hasPrefilledMatrixId.current = true;
-    form.setFieldValue('matrix_id', profile.username);
-    saveFieldAndRefreshNotifications('matrix_id', profile.username);
+    const username = profile.username;
+    form.setFieldValue('matrix_id', username);
+    saveFieldAndRefreshNotifications('matrix_id', username).then(success => {
+      if (!success) {
+        // Roll back so the form doesn't show an unpersisted value, and clear
+        // the ref so the next profile/notificationPrefs refetch can retry.
+        hasPrefilledMatrixId.current = false;
+        form.setFieldValue('matrix_id', '');
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile, notificationPrefs]);
 

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -2,8 +2,10 @@ import { Button, Card, Text, TextInput, Title, useMantineColorScheme } from '@ma
 import { useForm } from '@mantine/form';
 import { zod4Resolver } from 'mantine-form-zod-resolver';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useNotificationPreferences } from '@/hooks/useNotificationPreferences';
 import { useProfile } from '@/hooks/useProfile';
 import { useProfileFieldAutoSave } from '@/hooks/useProfileFieldAutoSave';
+import { useQueryClient } from '@tanstack/react-query';
 import { Check, Loader2, Monitor, Moon, Sun } from 'lucide-react';
 import React from 'react';
 import { z } from 'zod';
@@ -18,9 +20,26 @@ type ProfileFormData = z.infer<typeof profileSchema>;
 
 export const ProfileForm = () => {
   const { data: profile, isLoading } = useProfile();
+  const { data: notificationPrefs } = useNotificationPreferences();
   const { fieldStates, saveField } = useProfileFieldAutoSave();
   const { language, setLanguage, t } = useLanguage();
   const { colorScheme, setColorScheme } = useMantineColorScheme();
+  const queryClient = useQueryClient();
+  const hasPrefilledMatrixId = React.useRef(false);
+
+  // Notification availability (which channels a user can be reached on)
+  // depends on the profile fields saved above, so refresh it whenever one of
+  // those fields is saved — otherwise the Notifications card would keep
+  // showing its previous, now-stale set of channels until the next reload.
+  const saveFieldAndRefreshNotifications = React.useCallback(
+    async (fieldName: string, value: unknown) => {
+      await saveField(fieldName, value);
+      queryClient.invalidateQueries({
+        queryKey: ['notification-preferences', profile?.username],
+      });
+    },
+    [saveField, queryClient, profile?.username],
+  );
 
   const form = useForm<ProfileFormData>({
     validate: zod4Resolver(profileSchema),
@@ -41,6 +60,22 @@ export const ProfileForm = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile]);
+
+  // When Matrix notifications are configured on the backend but this user has
+  // no Matrix ID yet, prefill it with their bubble username (same as
+  // RocketChat, which always addresses users by their bubble username) so the
+  // Matrix notification options appear without requiring manual setup.
+  React.useEffect(() => {
+    if (hasPrefilledMatrixId.current) return;
+    if (!profile || !notificationPrefs) return;
+    if (!notificationPrefs.matrix_configured) return;
+    if (profile.matrix_id || !profile.username) return;
+
+    hasPrefilledMatrixId.current = true;
+    form.setFieldValue('matrix_id', profile.username);
+    saveFieldAndRefreshNotifications('matrix_id', profile.username);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [profile, notificationPrefs]);
 
   const getFieldBorderClass = (fieldName: string) => {
     const status = fieldStates[fieldName]?.status;
@@ -106,8 +141,18 @@ export const ProfileForm = () => {
             classNames={{ input: getFieldBorderClass('phone') }}
             rightSection={renderFieldStatusIcon('phone')}
             {...form.getInputProps('phone')}
-            onBlur={() => saveField('phone', form.getValues().phone)}
+            onBlur={() => saveFieldAndRefreshNotifications('phone', form.getValues().phone)}
           />
+
+          {notificationPrefs?.rocketchat_configured && (
+            <TextInput
+              label={t('profile.rocketchatUsername')}
+              description={t('profile.rocketchatUsernameDesc')}
+              value={profile?.username ?? ''}
+              readOnly
+              variant="filled"
+            />
+          )}
 
           <TextInput
             label={t('profile.matrixId')}
@@ -116,7 +161,7 @@ export const ProfileForm = () => {
             classNames={{ input: getFieldBorderClass('matrix_id') }}
             rightSection={renderFieldStatusIcon('matrix_id')}
             {...form.getInputProps('matrix_id')}
-            onBlur={() => saveField('matrix_id', form.getValues().matrix_id)}
+            onBlur={() => saveFieldAndRefreshNotifications('matrix_id', form.getValues().matrix_id)}
           />
         </form>
       </Card>

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -13,7 +13,6 @@ import { z } from 'zod';
 const profileSchema = z.object({
   name: z.string().optional(),
   phone: z.string().optional(),
-  matrix_id: z.string().optional(),
 });
 
 type ProfileFormData = z.infer<typeof profileSchema>;
@@ -25,7 +24,6 @@ export const ProfileForm = () => {
   const { language, setLanguage, t } = useLanguage();
   const { colorScheme, setColorScheme } = useMantineColorScheme();
   const queryClient = useQueryClient();
-  const hasPrefilledMatrixId = React.useRef(false);
 
   // Notification availability (which channels a user can be reached on)
   // depends on the profile fields saved above, so refresh it whenever one of
@@ -47,7 +45,6 @@ export const ProfileForm = () => {
     initialValues: {
       name: '',
       phone: '',
-      matrix_id: '',
     },
   });
 
@@ -56,37 +53,10 @@ export const ProfileForm = () => {
       form.setValues({
         name: profile.name ?? '',
         phone: profile.phone ?? '',
-        matrix_id: profile.matrix_id ?? '',
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile]);
-
-  // When Matrix notifications are configured on the backend but this user has
-  // no Matrix ID yet, prefill it with their bubble username (same as
-  // RocketChat, which always addresses users by their bubble username) so the
-  // Matrix notification options appear without requiring manual setup.
-  React.useEffect(() => {
-    if (hasPrefilledMatrixId.current) return;
-    if (!profile || !notificationPrefs) return;
-    if (!notificationPrefs.matrix_configured) return;
-    if (profile.matrix_id || !profile.username) return;
-
-    // Set the ref up front so a re-render during the save (e.g. from the
-    // optimistic form update below) can't trigger a second attempt.
-    hasPrefilledMatrixId.current = true;
-    const username = profile.username;
-    form.setFieldValue('matrix_id', username);
-    saveFieldAndRefreshNotifications('matrix_id', username).then(success => {
-      if (!success) {
-        // Roll back so the form doesn't show an unpersisted value, and clear
-        // the ref so the next profile/notificationPrefs refetch can retry.
-        hasPrefilledMatrixId.current = false;
-        form.setFieldValue('matrix_id', '');
-      }
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile, notificationPrefs]);
 
   const getFieldBorderClass = (fieldName: string) => {
     const status = fieldStates[fieldName]?.status;
@@ -164,16 +134,6 @@ export const ProfileForm = () => {
               variant="filled"
             />
           )}
-
-          <TextInput
-            label={t('profile.matrixId')}
-            placeholder="@alice:matrix.org"
-            description={t('profile.matrixIdDesc')}
-            classNames={{ input: getFieldBorderClass('matrix_id') }}
-            rightSection={renderFieldStatusIcon('matrix_id')}
-            {...form.getInputProps('matrix_id')}
-            onBlur={() => saveFieldAndRefreshNotifications('matrix_id', form.getValues().matrix_id)}
-          />
         </form>
       </Card>
 

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -545,9 +545,9 @@ const translations = {
     'profile.emailReminderDesc': 'Receive email reminders for bookings and messages',
     'profile.notifications': 'Notifications',
     'profile.notificationsDesc':
-      'Choose how you want to be notified. Channels appear once configured and the matching profile field (RocketChat username, Signal phone number, Matrix ID, email) is filled in.',
+      'Choose how you want to be notified. A channel appears once an administrator has configured it. RocketChat and email use your account automatically; Signal needs a phone number on your profile; Matrix needs a Matrix ID, which you can set right here.',
     'profile.notificationsUnavailable':
-      'No notification channels are available yet. Add a phone number or Matrix ID, or ask an administrator to configure the notification services.',
+      'No notification channels are available yet. Add a phone number for Signal, or ask an administrator to configure the notification services.',
     'profile.channelRocketchat': 'RocketChat',
     'profile.channelSignal': 'Signal',
     'profile.channelMatrix': 'Matrix',
@@ -1264,9 +1264,9 @@ const translations = {
     'profile.emailReminderDesc': 'E-Mail-Erinnerungen für Buchungen und Nachrichten erhalten',
     'profile.notifications': 'Benachrichtigungen',
     'profile.notificationsDesc':
-      'Wähle, wie du benachrichtigt werden möchtest. Kanäle erscheinen, sobald sie konfiguriert sind und das passende Profilfeld (RocketChat-Benutzername, Signal-Telefonnummer, Matrix-ID, E-Mail) ausgefüllt ist.',
+      'Wähle, wie du benachrichtigt werden möchtest. Ein Kanal erscheint, sobald ihn ein Administrator konfiguriert hat. RocketChat und E-Mail nutzen automatisch dein Konto; Signal benötigt eine Telefonnummer in deinem Profil; Matrix benötigt eine Matrix-ID, die du direkt hier festlegen kannst.',
     'profile.notificationsUnavailable':
-      'Es sind noch keine Benachrichtigungskanäle verfügbar. Hinterlege eine Telefonnummer oder Matrix-ID oder bitte einen Administrator, die Benachrichtigungsdienste zu konfigurieren.',
+      'Es sind noch keine Benachrichtigungskanäle verfügbar. Hinterlege eine Telefonnummer für Signal oder bitte einen Administrator, die Benachrichtigungsdienste zu konfigurieren.',
     'profile.channelRocketchat': 'RocketChat',
     'profile.channelSignal': 'Signal',
     'profile.channelMatrix': 'Matrix',

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -534,6 +534,9 @@ const translations = {
     'profile.manage': 'Manage your profile information',
     'profile.name': 'Name',
     'profile.phone': 'Phone',
+    'profile.rocketchatUsername': 'RocketChat username',
+    'profile.rocketchatUsernameDesc':
+      'Matches your bubble username and is used for RocketChat notifications',
     'profile.matrixId': 'Matrix ID',
     'profile.matrixIdDesc': 'Your Matrix user ID, used for Matrix notifications',
     'profile.bio': 'Bio',
@@ -1250,6 +1253,9 @@ const translations = {
     'profile.manage': 'Verwalte deine Profilinformationen',
     'profile.name': 'Name',
     'profile.phone': 'Telefon',
+    'profile.rocketchatUsername': 'RocketChat-Benutzername',
+    'profile.rocketchatUsernameDesc':
+      'Entspricht deinem bubble-Benutzernamen und wird für RocketChat-Benachrichtigungen verwendet',
     'profile.matrixId': 'Matrix-ID',
     'profile.matrixIdDesc': 'Deine Matrix-Benutzer-ID, für Matrix-Benachrichtigungen',
     'profile.bio': 'Bio',

--- a/frontend/src/hooks/useProfileFieldAutoSave.ts
+++ b/frontend/src/hooks/useProfileFieldAutoSave.ts
@@ -28,16 +28,18 @@ export const useProfileFieldAutoSave = () => {
   }, []);
 
   const saveField = useCallback(
-    async (fieldName: string, value: unknown) => {
+    async (fieldName: string, value: unknown): Promise<boolean> => {
       setFieldState(fieldName, { status: 'saving' });
       try {
         const body: PatchedProfile = { [fieldName]: value };
         await profilesMePartialUpdate({ body });
         setFieldState(fieldName, { status: 'success' });
         clearSuccessAfterDelay(fieldName);
+        return true;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Failed to save field';
         setFieldState(fieldName, { status: 'error', errorMessage });
+        return false;
       }
     },
     [setFieldState, clearSuccessAfterDelay],

--- a/frontend/src/services/django/types.gen.ts
+++ b/frontend/src/services/django/types.gen.ts
@@ -951,22 +951,27 @@ export type Message = {
  * created items.
  */
 export type NotificationPreferenceMe = {
+    readonly webpush_configured: boolean;
     readonly webpush_available: boolean;
     readonly webpush_target: string;
     webpush_messages?: boolean;
     webpush_new_item?: boolean;
+    readonly rocketchat_configured: boolean;
     readonly rocketchat_available: boolean;
     readonly rocketchat_target: string;
     rocketchat_messages?: boolean;
     rocketchat_new_item?: boolean;
+    readonly signal_configured: boolean;
     readonly signal_available: boolean;
     readonly signal_target: string;
     signal_messages?: boolean;
     signal_new_item?: boolean;
+    readonly matrix_configured: boolean;
     readonly matrix_available: boolean;
     readonly matrix_target: string;
     matrix_messages?: boolean;
     matrix_new_item?: boolean;
+    readonly email_configured: boolean;
     readonly email_available: boolean;
     readonly email_target: string;
     email_messages?: boolean;
@@ -1501,22 +1506,27 @@ export type PatchedMessage = {
  * created items.
  */
 export type PatchedNotificationPreferenceMe = {
+    readonly webpush_configured?: boolean;
     readonly webpush_available?: boolean;
     readonly webpush_target?: string;
     webpush_messages?: boolean;
     webpush_new_item?: boolean;
+    readonly rocketchat_configured?: boolean;
     readonly rocketchat_available?: boolean;
     readonly rocketchat_target?: string;
     rocketchat_messages?: boolean;
     rocketchat_new_item?: boolean;
+    readonly signal_configured?: boolean;
     readonly signal_available?: boolean;
     readonly signal_target?: string;
     signal_messages?: boolean;
     signal_new_item?: boolean;
+    readonly matrix_configured?: boolean;
     readonly matrix_available?: boolean;
     readonly matrix_target?: string;
     matrix_messages?: boolean;
     matrix_new_item?: boolean;
+    readonly email_configured?: boolean;
     readonly email_available?: boolean;
     readonly email_target?: string;
     email_messages?: boolean;


### PR DESCRIPTION
## Summary
- RocketChat always addresses a user by their bubble username, so once `APPRISE_ROCKETCHAT_URL` is configured, the profile page now shows the (read-only) RocketChat username and the RocketChat notification options appear automatically — no per-user setup needed.
- Matrix needs a per-user Matrix ID. Once `APPRISE_MATRIX_URL` is configured, a user's empty Matrix ID is now prefilled and saved with their bubble username, which immediately makes the Matrix channel and its notification options available (still editable to a real `@user:server` address).
- **The Matrix ID field now lives inside the Notifications section**, right in the Matrix panel next to its notification toggles, instead of the main Profile Settings card. That panel now appears as soon as Matrix is configured on the backend (not only once an ID is already set), since it's now the only place to enter one.
- **Email notifications** (driven by `APPRISE_MAILTOS_URL`, i.e. an SMTP server configured for Apprise) already worked the same way RocketChat does — available automatically once configured, using the account email as the target — and already started **disabled by default** until the user opts in. Added explicit test coverage confirming that.
- Added a `<provider>_configured` field to `NotificationPreferenceMeSerializer` (backend-configuration state, independent of whether the user is reachable yet) so the frontend can decide when to prefill/show a channel.
- The Notifications card now refreshes automatically after `phone`/`matrix_id` are saved, instead of requiring a manual reload to see newly available channels.

## Test plan
- [x] `uv run pytest bubble/notifications/tests/test_serializers.py bubble/notifications/tests/test_channels.py` — passing (10 tests)
- [x] `uv run ruff check` / `uv run ruff format --check` on changed backend files
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` / `npx prettier --check` on changed frontend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUqR86BPHZaCkkZKuQcJUS