### PR TITLE
fix(nav): align back button with header title and unify header sizes

### DIFF
--- a/frontend/src/pages/Bookings.tsx
+++ b/frontend/src/pages/Bookings.tsx
@@ -392,9 +392,14 @@ const MyBookingsPage = () => {
       <div className="flex flex-col h-full">
         {/* Header — hidden on mobile once a conversation is open, where the
             panel's own back button takes over. */}
-        <div className={cn('shrink-0', selectedBookingId && 'hidden md:block')}>
+        <div
+          className={cn(
+            'flex items-center gap-2 mb-4 shrink-0',
+            selectedBookingId && 'hidden md:flex',
+          )}
+        >
           <BackButton />
-          <Title order={1} className="mb-4">
+          <Title order={1} size="h3">
             {t('bookings.title')}
           </Title>
         </div>

--- a/frontend/src/pages/CollectionDetail.tsx
+++ b/frontend/src/pages/CollectionDetail.tsx
@@ -23,6 +23,7 @@ import {
   Text,
   TextInput,
   Textarea,
+  Title,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { BookMarked, Edit3, History, ShoppingCart, Trash2 } from 'lucide-react';
@@ -124,14 +125,15 @@ const CollectionDetail = () => {
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8 space-y-6">
-      <BackButton />
-
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <BackButton />
           <BookMarked className="h-6 w-6 text-primary shrink-0" />
           <div className="min-w-0">
-            <h1 className="text-2xl font-bold truncate">{collection.name}</h1>
+            <Title order={1} size="h3" className="truncate">
+              {collection.name}
+            </Title>
             {collection.description && (
               <Text size="sm" c="dimmed" className="mt-1">
                 {collection.description}

--- a/frontend/src/pages/Collections.tsx
+++ b/frontend/src/pages/Collections.tsx
@@ -18,6 +18,7 @@ import {
   Text,
   TextInput,
   Textarea,
+  Title,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { BookMarked, ChevronRight, Grid3X3, List, Plus, Search, Trash2 } from 'lucide-react';
@@ -93,13 +94,13 @@ const Collections = () => {
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8 space-y-6">
-      <BackButton />
-
       {/* Header */}
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <BookMarked className="h-6 w-6 text-primary" />
-          <h1 className="text-2xl font-bold">{t('collections.header.myCollections')}</h1>
+        <div className="flex items-center gap-2">
+          <BackButton />
+          <Title order={1} size="h3">
+            {t('collections.header.myCollections')}
+          </Title>
         </div>
         <div className="flex items-center gap-2">
           {/* View mode toggle */}

--- a/frontend/src/pages/EditItem.tsx
+++ b/frontend/src/pages/EditItem.tsx
@@ -748,12 +748,15 @@ const EditItem = (props: EditItemExtensionProps = {}) => {
 
   return (
     <div className="container mx-auto py-8 space-y-0 p-3">
-      <BackButton className="mb-6" onClick={() => handleGuardedNavigate(-1)} />
-
       <Card withBorder padding="lg">
         <div className="mb-6">
           <div className="flex items-center justify-between">
-            <Title order={3}>{editItemUuid ? t('itemDetail.editItem') : t('editItem.name')}</Title>
+            <div className="flex items-center gap-2">
+              <BackButton onClick={() => handleGuardedNavigate(-1)} />
+              <Title order={3}>
+                {editItemUuid ? t('itemDetail.editItem') : t('editItem.name')}
+              </Title>
+            </div>
             <div className="flex gap-2 items-center">
               {/* ── Desktop: inline buttons ── */}
               <div className="hidden md:flex gap-2">

--- a/frontend/src/pages/ItemBookingHistory.tsx
+++ b/frontend/src/pages/ItemBookingHistory.tsx
@@ -44,11 +44,12 @@ const ItemBookingHistory = () => {
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">
-      <BackButton className="mb-6" />
-
-      <Title order={2} mb={4}>
-        {t('itemBookings.title')}
-      </Title>
+      <div className="flex items-center gap-2 mb-4">
+        <BackButton />
+        <Title order={1} size="h3">
+          {t('itemBookings.title')}
+        </Title>
+      </div>
       {item?.name && (
         <Text c="dimmed" mb="lg">
           {item.name}

--- a/frontend/src/pages/MyItems.tsx
+++ b/frontend/src/pages/MyItems.tsx
@@ -228,9 +228,13 @@ const MyItems = () => {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <BackButton className="mb-4" />
       <div className="flex items-center justify-between mb-8">
-        <Title order={1}>{t('myItems.title')}</Title>
+        <div className="flex items-center gap-2">
+          <BackButton />
+          <Title order={1} size="h3">
+            {t('myItems.title')}
+          </Title>
+        </div>
         <div className="flex items-center gap-4">
           {/* View Mode Toggle */}
           <div className="flex items-center gap-1 border rounded-lg p-1">

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -10,9 +10,13 @@ const Profile = () => {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl">
-      <BackButton className="mb-4" />
       <div className="mb-8">
-        <Title order={1}>{t('profile.title')}</Title>
+        <div className="flex items-center gap-2">
+          <BackButton />
+          <Title order={1} size="h3">
+            {t('profile.title')}
+          </Title>
+        </div>
         <Text c="dimmed" className="mt-2">
           {t('profile.manage')}
         </Text>


### PR DESCRIPTION
Follow-up to #126.

## Summary
- Put the back arrow on the same row as each page's title, to its left, instead of stacked above it — on My Items, My Collections, My Bookings, Profile Settings, Item Booking History, Collection Detail, and Edit Item.
- Resize each of those titles to match the "List New Item" wizard header (`Title order={1} size="h3"`), so page headers are visually consistent across the app. Edit Item's `Title order={3}` is left as-is since it already renders at h3 size by default.
- Remove the `BookMarked` icon from the My Collections header (Collection Detail keeps its icon — only My Collections was called out).

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint` on all changed files (no new warnings/errors; pre-existing issues elsewhere untouched)
- [x] `npx prettier --check` on all changed files
- [ ] Manual click-through in a browser (not performed in this session — these pages require an authenticated session with seeded data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174odj9DwBc1JdnwYBoQVte

---
_Generated by [Claude Code](https://claude.ai/code/session_0174odj9DwBc1JdnwYBoQVte)_