### PR TITLE
feat(search): restrict search bar to desktop and mobile home/browse, autofocus on tap

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -35,6 +35,17 @@ export const Header = () => {
 
   const unreadCount = unreadMessages?.count || 0;
 
+  // The search bar (and its icon) is always shown on desktop. On mobile it's
+  // only relevant on the screens that act as its entry points — the start
+  // page and the browse/search screen itself — so it's hidden everywhere
+  // else to keep those headers uncluttered. `md:block` keeps it unconditional
+  // on desktop regardless of route.
+  const showSearchOnMobile = location.pathname === '/' || location.pathname === BROWSE_PATH;
+  const searchWrapperClassName = cn(
+    'min-w-0 flex-1 max-w-lg md:block',
+    showSearchOnMobile ? 'block' : 'hidden',
+  );
+
   const handleSignOut = async () => {
     await signOut();
     navigate('/');
@@ -54,7 +65,7 @@ export const Header = () => {
                 <p className="text-xs text-muted-foreground">Community Network</p>
               </div>
             </NavLink>
-            <div className="min-w-0 flex-1 max-w-lg">
+            <div className={searchWrapperClassName}>
               <SearchBar loggedIn={false} />
             </div>
 
@@ -90,7 +101,7 @@ export const Header = () => {
           </NavLink>
 
           {/* Search Bar */}
-          <div className="min-w-0 flex-1 max-w-lg">
+          <div className={searchWrapperClassName}>
             <SearchBar loggedIn />
           </div>
 

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -100,10 +100,22 @@ export const MobileBottomNav = () => {
             <UnstyledButton
               key={item.key}
               // Re-tapping the active tab scrolls to top rather than pushing a
-              // duplicate history entry.
-              onClick={() =>
-                active ? window.scrollTo({ top: 0, behavior: 'smooth' }) : navigate(item.to)
-              }
+              // duplicate history entry. The search tab is the exception: it
+              // always (re-)focuses the search bar so tapping it starts typing
+              // right away, whether or not the browse screen is already open.
+              onClick={() => {
+                if (item.key === 'nav.search') {
+                  // Preserve any filters already in the URL when re-tapping
+                  // from the browse screen itself, rather than dropping them.
+                  navigate(
+                    { pathname: item.to, search: active ? location.search : '' },
+                    { state: { focusSearch: true }, replace: active },
+                  );
+                  return;
+                }
+                if (active) window.scrollTo({ top: 0, behavior: 'smooth' });
+                else navigate(item.to);
+              }}
               aria-current={active ? 'page' : undefined}
               className="flex flex-1 flex-col items-center justify-center gap-0.5"
             >

--- a/frontend/src/components/layout/SearchBar.tsx
+++ b/frontend/src/components/layout/SearchBar.tsx
@@ -96,6 +96,21 @@ export const SearchBar = ({ loggedIn, className }: SearchBarProps) => {
   const maxPriceValue = currentParams.get('maxPrice') ?? '';
 
   const [opened, setOpened] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // The mobile nav's search tab navigates here with `focusSearch` state so
+  // tapping it starts typing right away, instead of landing on the browse
+  // screen with the bar merely visible. Focusing the field opens the popover
+  // via its own `onFocus` handler below. The state is consumed once via a
+  // replace navigation so it doesn't refire on back/forward or a later
+  // remount.
+  useEffect(() => {
+    const state = location.state as { focusSearch?: boolean } | null;
+    if (!state?.focusSearch) return;
+    searchInputRef.current?.focus();
+    navigate(location.pathname + location.search, { replace: true });
+  }, [location, navigate]);
+
   const facets: Facet[] = useMemo(
     () =>
       (['type', 'category', 'collection', 'availability', 'owner', 'price'] as const).filter(
@@ -540,6 +555,7 @@ export const SearchBar = ({ loggedIn, className }: SearchBarProps) => {
               </Pill>
             ))}
             <PillsInput.Field
+              ref={searchInputRef}
               value={inputValue}
               placeholder={chips.length > 0 ? '' : t('header.search')}
               onFocus={() => setOpened(true)}

--- a/frontend/src/components/layout/SearchBar.tsx
+++ b/frontend/src/components/layout/SearchBar.tsx
@@ -108,7 +108,7 @@ export const SearchBar = ({ loggedIn, className }: SearchBarProps) => {
     const state = location.state as { focusSearch?: boolean } | null;
     if (!state?.focusSearch) return;
     searchInputRef.current?.focus();
-    navigate(location.pathname + location.search, { replace: true });
+    navigate(location.pathname + location.search + location.hash, { replace: true });
   }, [location, navigate]);
 
   const facets: Facet[] = useMemo(


### PR DESCRIPTION
## Summary
- The header search bar (input + icon) now stays visible on desktop on every screen, unchanged from before.
- On mobile it's now only shown on the start page (`/`) and the browse/search screen (`/browse`); it's hidden from the header on every other mobile screen.
- Tapping the search icon in the mobile bottom nav now moves focus directly into the search field (and opens its filter popover) instead of just navigating to the browse screen and leaving the bar unfocused. Re-tapping while already on the browse screen preserves any active filters in the URL.

## Implementation
- `Header.tsx`: computed a shared `searchWrapperClassName` (`hidden`/`block` based on route, `md:block` to stay unconditional on desktop) applied to both the logged-in and logged-out search bar wrappers.
- `MobileBottomNav.tsx`: the search tab's `onClick` now navigates with `{ state: { focusSearch: true } }`, preserving the current query string when already on `/browse`.
- `SearchBar.tsx`: added an input ref and an effect that focuses the field (and clears the one-shot navigation state via a `replace` navigation) when `focusSearch` is present in `location.state`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on the changed files
- [x] `npm run build` succeeds
- [ ] Manual verification in a browser was not performed (no running backend/dev environment was set up in this session) — please confirm mobile show/hide behavior and the autofocus-on-tap interaction visually before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MeZYES7ohxECXq2LJQKasX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeZYES7ohxECXq2LJQKasX)_