### PR TITLE
feat(mobile-nav): hide header outside home/browse, defer search focus to second tap

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -35,16 +35,17 @@ export const Header = () => {
 
   const unreadCount = unreadMessages?.count || 0;
 
-  // The search bar (and its icon) is always shown on desktop. On mobile it's
-  // only relevant on the screens that act as its entry points — the start
-  // page and the browse/search screen itself — so it's hidden everywhere
-  // else to keep those headers uncluttered. `md:block` keeps it unconditional
-  // on desktop regardless of route.
-  const showSearchOnMobile = location.pathname === '/' || location.pathname === BROWSE_PATH;
-  const searchWrapperClassName = cn(
-    'min-w-0 flex-1 max-w-lg md:block',
-    showSearchOnMobile ? 'block' : 'hidden',
+  // The header (logo + search bar) is always shown on desktop. On mobile it's
+  // only relevant on the screens that act as the search bar's entry points —
+  // the start page and the browse/search screen itself — so the whole bar is
+  // hidden everywhere else to keep those screens uncluttered. `md:block`
+  // keeps it unconditional on desktop regardless of route.
+  const showHeaderOnMobile = location.pathname === '/' || location.pathname === BROWSE_PATH;
+  const headerClassName = cn(
+    'sticky top-0 z-50 w-full border-b border-border bg-background/95 md:block md:bg-background/80 md:backdrop-blur-md',
+    showHeaderOnMobile ? 'block' : 'hidden',
   );
+  const searchWrapperClassName = 'min-w-0 flex-1 max-w-lg';
 
   const handleSignOut = async () => {
     await signOut();
@@ -53,7 +54,7 @@ export const Header = () => {
 
   if (!user) {
     return (
-      <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 md:bg-background/80 md:backdrop-blur-md">
+      <header className={headerClassName}>
         <div className="mx-auto w-full max-w-[1400px] px-4 py-3 sm:px-8">
           <div className="flex items-center justify-between gap-2 sm:gap-4">
             <NavLink to="/" className="flex shrink-0 items-center gap-3">
@@ -86,7 +87,7 @@ export const Header = () => {
   }
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 md:bg-background/80 md:backdrop-blur-md">
+    <header className={headerClassName}>
       <div className="mx-auto w-full max-w-[1400px] px-4 py-3 sm:px-8">
         <div className="flex items-center justify-between gap-2 sm:gap-4">
           {/* Logo */}

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -100,16 +100,17 @@ export const MobileBottomNav = () => {
             <UnstyledButton
               key={item.key}
               // Re-tapping the active tab scrolls to top rather than pushing a
-              // duplicate history entry. The search tab is the exception: it
-              // always (re-)focuses the search bar so tapping it starts typing
-              // right away, whether or not the browse screen is already open.
+              // duplicate history entry. The search tab is the exception: the
+              // first tap just opens the browse screen, and only a second tap
+              // (while already there) focuses the search bar — so tapping the
+              // tab doesn't yank the keyboard open immediately.
               onClick={() => {
                 if (item.key === 'nav.search') {
                   // Preserve any filters already in the URL when re-tapping
                   // from the browse screen itself, rather than dropping them.
                   navigate(
                     { pathname: item.to, search: active ? location.search : '' },
-                    { state: { focusSearch: true }, replace: active },
+                    { state: { focusSearch: active }, replace: active },
                   );
                   return;
                 }


### PR DESCRIPTION
## Summary
- Hide the mobile top header bar (logo + search) entirely on every screen except the start page and the browse/search page, where the search bar is actually usable. Desktop is unaffected — the header stays visible there on every route.
- Tapping the search tab in the bottom nav now only navigates to the browse screen on the first tap, without immediately focusing (and popping the keyboard for) the search bar. A second tap, while already on browse, focuses the search bar.

## Changes
- `frontend/src/components/layout/Header.tsx`: derive a `headerClassName` that hides the whole `<header>` on mobile unless the route is `/` or the browse path (`md:block` keeps it always visible on desktop).
- `frontend/src/components/layout/MobileBottomNav.tsx`: pass `focusSearch: active` instead of always `true`, so the search bar only autofocuses when the search tab is already the active tab.

## Test plan
- [x] `npm run typecheck` (frontend)
- [x] `npx eslint` on the changed files
- [x] `npx prettier --check` on the changed files
- [ ] Manual verification on a running app with backend (not exercised in this environment — no backend available to log in and click through the mobile nav)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLb3fwQGvAMxpQLyvbQsma)_