### PR TITLE
fix(notifications): default Matrix ID to a full @user:hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ Users then choose, per channel, which events they want:
 
 The phone number can be filled in manually on the profile, or is pre-populated from the `phone_number` claim of your OIDC provider when available (the `phone` scope is requested automatically).
 
-RocketChat and email always address a user by their bubble username/account email, so they need no separate field — once `APPRISE_ROCKETCHAT_URL`/`APPRISE_MAILTOS_URL` is configured, those channels and their notification options appear automatically (email notifications, like every other channel, start out **disabled** until the user opts in). Matrix works similarly but needs a per-user Matrix ID: once `APPRISE_MATRIX_URL` is configured, the Matrix panel appears in the **Notifications** section of the profile with an editable Matrix ID field, prefilled with the user's bubble username so the channel becomes available immediately (they can still edit it to their real `@user:server` address).
+RocketChat and email always address a user by their bubble username/account email, so they need no separate field — once `APPRISE_ROCKETCHAT_URL`/`APPRISE_MAILTOS_URL` is configured, those channels and their notification options appear automatically (email notifications, like every other channel, start out **disabled** until the user opts in). Matrix works similarly but needs a per-user Matrix ID: once `APPRISE_MATRIX_URL` is configured, the Matrix panel appears in the **Notifications** section of the profile with an editable Matrix ID field, prefilled with `@<bubble username>:<homeserver>` so the channel becomes available immediately (they can still edit it to their real `@user:server` address).
+
+The `<homeserver>` part of that prefill defaults to `DJANGO_ALLOWED_HOSTS[0]` (Matrix IDs conventionally use the bare site domain even when the client-server API itself lives on a subdomain, e.g. `matrix.example.com`, via `.well-known` delegation). Set `APPRISE_MATRIX_HOSTNAME` to override it when that doesn't hold, e.g.:
+
+```env
+APPRISE_MATRIX_HOSTNAME=example.com
+```
 
 # Federation (ActivityPub)
 

--- a/backend/bubble/notifications/api/serializers.py
+++ b/backend/bubble/notifications/api/serializers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rest_framework import serializers
 
 from bubble.notifications.channels import (
+    default_matrix_id,
     is_backend_configured,
     is_channel_available,
     resolve_target,
@@ -58,7 +59,16 @@ class NotificationPreferenceMeSerializer(serializers.Serializer):
     * ``<provider>_<group>`` (read/write): per event-group opt-in toggles.
       ``messages`` covers new messages and bookings; ``new_item`` covers newly
       created items.
+
+    Additionally exposes ``matrix_default_id`` (read-only): the Matrix ID the
+    frontend should prefill for this user (their bubble username on this
+    deployment's own homeserver — see ``APPRISE_MATRIX_HOSTNAME``), or "" when
+    that can't be determined. Every other channel's target is derived
+    automatically (bubble username/email), so only Matrix needs a suggested
+    default for the user to accept or edit.
     """
+
+    matrix_default_id = serializers.CharField(read_only=True)
 
     def get_fields(self):
         fields = super().get_fields()
@@ -82,7 +92,7 @@ class NotificationPreferenceMeSerializer(serializers.Serializer):
             for p in NotificationPreference.objects.filter(user=user)
         }
 
-        data: dict[str, object] = {}
+        data: dict[str, object] = {"matrix_default_id": default_matrix_id(user)}
         for provider in PROVIDERS:
             data[_configured_field(provider)] = is_backend_configured(provider)
             data[_available_field(provider)] = is_channel_available(provider, user)

--- a/backend/bubble/notifications/channels.py
+++ b/backend/bubble/notifications/channels.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from constance import config
+from django.conf import settings
 
 from bubble.notifications import webpush
 from bubble.notifications.models import NotificationPreference
@@ -65,6 +66,20 @@ def resolve_target(provider_type: str, user: User) -> str:
     if provider_type == ProviderType.EMAIL:
         return (user.email or "").strip()
     return ""
+
+
+def default_matrix_id(user: User) -> str:
+    """Return the Matrix ID a user would have on this deployment's homeserver
+    (e.g. "@alice:example.com"), or "" when either half is unavailable.
+
+    Used to prefill the Matrix ID field with a sensible guess — the user's
+    bubble username on this site's own homeserver — see APPRISE_MATRIX_HOSTNAME.
+    """
+    username = (user.username or "").strip()
+    hostname = settings.APPRISE_MATRIX_HOSTNAME
+    if not username or not hostname:
+        return ""
+    return f"@{username}:{hostname}"
 
 
 def is_backend_configured(provider_type: str) -> bool:

--- a/backend/bubble/notifications/channels.py
+++ b/backend/bubble/notifications/channels.py
@@ -75,8 +75,8 @@ def default_matrix_id(user: User) -> str:
     Used to prefill the Matrix ID field with a sensible guess — the user's
     bubble username on this site's own homeserver — see APPRISE_MATRIX_HOSTNAME.
     """
-    username = (user.username or "").strip()
-    hostname = settings.APPRISE_MATRIX_HOSTNAME
+    username = (user.username or "").strip().lstrip("@")
+    hostname = (settings.APPRISE_MATRIX_HOSTNAME or "").strip()
     if not username or not hostname:
         return ""
     return f"@{username}:{hostname}"

--- a/backend/bubble/notifications/tests/test_channels.py
+++ b/backend/bubble/notifications/tests/test_channels.py
@@ -86,6 +86,15 @@ def test_default_matrix_id_empty_without_hostname() -> None:
 
 @pytest.mark.django_db
 @override_settings(APPRISE_MATRIX_HOSTNAME="example.com")
+def test_default_matrix_id_does_not_double_prefix_at_sign() -> None:
+    # Django's UnicodeUsernameValidator allows "@" in usernames, so a user
+    # named "@alice" shouldn't produce the invalid "@@alice:example.com".
+    user = UserFactory(username="@alice")
+    assert default_matrix_id(user) == "@alice:example.com"
+
+
+@pytest.mark.django_db
+@override_settings(APPRISE_MATRIX_HOSTNAME="example.com")
 def test_default_matrix_id_empty_without_username() -> None:
     user = UserFactory(username="")
     assert default_matrix_id(user) == ""

--- a/backend/bubble/notifications/tests/test_channels.py
+++ b/backend/bubble/notifications/tests/test_channels.py
@@ -1,8 +1,10 @@
 import pytest
 from constance.test import override_config
+from django.test import override_settings
 
 from bubble.notifications.channels import (
     build_apprise_url,
+    default_matrix_id,
     is_channel_available,
     resolve_target,
 )
@@ -66,3 +68,24 @@ def test_is_channel_available_requires_backend_and_target() -> None:
 
     # RocketChat has a target (username) but no backend URL configured.
     assert is_channel_available(ProviderType.ROCKETCHAT, user) is False
+
+
+@pytest.mark.django_db
+@override_settings(APPRISE_MATRIX_HOSTNAME="example.com")
+def test_default_matrix_id_combines_username_and_hostname() -> None:
+    user = UserFactory(username="alice")
+    assert default_matrix_id(user) == "@alice:example.com"
+
+
+@pytest.mark.django_db
+@override_settings(APPRISE_MATRIX_HOSTNAME="")
+def test_default_matrix_id_empty_without_hostname() -> None:
+    user = UserFactory(username="alice")
+    assert default_matrix_id(user) == ""
+
+
+@pytest.mark.django_db
+@override_settings(APPRISE_MATRIX_HOSTNAME="example.com")
+def test_default_matrix_id_empty_without_username() -> None:
+    user = UserFactory(username="")
+    assert default_matrix_id(user) == ""

--- a/backend/bubble/notifications/tests/test_serializers.py
+++ b/backend/bubble/notifications/tests/test_serializers.py
@@ -1,5 +1,6 @@
 import pytest
 from constance.test import override_config
+from django.test import override_settings
 
 from bubble.notifications.api.serializers import NotificationPreferenceMeSerializer
 from bubble.notifications.models import EventType, NotificationPreference
@@ -42,6 +43,7 @@ def test_to_representation_reports_availability_and_toggles() -> None:
 
 @pytest.mark.django_db
 @override_config(APPRISE_MATRIX_URL="matrixs://user:pass@matrix.example.com/{target}")
+@override_settings(APPRISE_MATRIX_HOSTNAME="example.com")
 def test_configured_is_true_even_without_a_user_target() -> None:
     # "configured" reflects backend setup only, unlike "available" which also
     # requires the user to have filled in their address for the channel.
@@ -52,6 +54,7 @@ def test_configured_is_true_even_without_a_user_target() -> None:
     assert data["matrix_configured"] is True
     assert data["matrix_available"] is False
     assert data["matrix_target"] == ""
+    assert data["matrix_default_id"] == "@alice:example.com"
 
 
 @pytest.mark.django_db

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -38,6 +38,17 @@ if not FRONTEND_URL:
         f"https://{ALLOWED_HOSTS[0]}" if ALLOWED_HOSTS else "http://localhost:3000"
     )
 
+# Homeserver part of a Matrix ID (the "example.com" in "@alice:example.com").
+# Matrix IDs conventionally use the bare site domain even when the
+# client-server API itself is served from a subdomain (e.g. matrix.example.com),
+# via .well-known delegation — so this defaults to the site's own domain
+# rather than parsing it out of APPRISE_MATRIX_URL. Override it explicitly
+# when that doesn't hold (e.g. the Matrix homeserver lives on a different
+# domain entirely).
+APPRISE_MATRIX_HOSTNAME = env("APPRISE_MATRIX_HOSTNAME", default="") or (
+    ALLOWED_HOSTS[0] if ALLOWED_HOSTS else ""
+)
+
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = env.bool("DJANGO_DEBUG", False)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -45,7 +45,7 @@ if not FRONTEND_URL:
 # rather than parsing it out of APPRISE_MATRIX_URL. Override it explicitly
 # when that doesn't hold (e.g. the Matrix homeserver lives on a different
 # domain entirely).
-APPRISE_MATRIX_HOSTNAME = env("APPRISE_MATRIX_HOSTNAME", default="") or (
+APPRISE_MATRIX_HOSTNAME = env("APPRISE_MATRIX_HOSTNAME", default="").strip() or (
     ALLOWED_HOSTS[0] if ALLOWED_HOSTS else ""
 )
 

--- a/frontend/src/components/profile/NotificationSettings.tsx
+++ b/frontend/src/components/profile/NotificationSettings.tsx
@@ -78,21 +78,21 @@ export const NotificationSettings = () => {
   );
 
   // When Matrix notifications are configured on the backend but this user has
-  // no Matrix ID yet, prefill it with their bubble username (same as
-  // RocketChat, which always addresses users by their bubble username) so the
-  // Matrix notification options work without requiring manual setup.
+  // no Matrix ID yet, prefill it with their full Matrix ID on this
+  // deployment's own homeserver (`@username:hostname`, from matrix_default_id)
+  // so the Matrix notification options work without requiring manual setup.
   React.useEffect(() => {
     if (hasPrefilledMatrixId.current) return;
     if (!profile || !prefs) return;
     if (!prefs.matrix_configured) return;
-    if (profile.matrix_id || !profile.username) return;
+    if (profile.matrix_id || !prefs.matrix_default_id) return;
 
     // Set the ref up front so a re-render during the save can't trigger a
     // second attempt.
     hasPrefilledMatrixId.current = true;
-    const username = profile.username;
-    matrixIdForm.setFieldValue('matrix_id', username);
-    saveMatrixId(username).then(success => {
+    const defaultId = prefs.matrix_default_id;
+    matrixIdForm.setFieldValue('matrix_id', defaultId);
+    saveMatrixId(defaultId).then(success => {
       if (!success) {
         // Roll back so the form doesn't show an unpersisted value, and clear
         // the ref so the next profile/prefs refetch can retry.

--- a/frontend/src/services/django/types.gen.ts
+++ b/frontend/src/services/django/types.gen.ts
@@ -951,6 +951,7 @@ export type Message = {
  * created items.
  */
 export type NotificationPreferenceMe = {
+    readonly matrix_default_id: string;
     readonly webpush_configured: boolean;
     readonly webpush_available: boolean;
     readonly webpush_target: string;
@@ -1506,6 +1507,7 @@ export type PatchedMessage = {
  * created items.
  */
 export type PatchedNotificationPreferenceMe = {
+    readonly matrix_default_id?: string;
     readonly webpush_configured?: boolean;
     readonly webpush_available?: boolean;
     readonly webpush_target?: string;


### PR DESCRIPTION
## Summary
- The Matrix ID prefill used the bare bubble username (e.g. `fabian.helm`), which isn't a valid Matrix user ID — Apprise's `IS_USER` pattern requires an `@` prefix and a `:homeserver` suffix, so notifications silently had nowhere valid to go.
- Added `APPRISE_MATRIX_HOSTNAME`, defaulting to `DJANGO_ALLOWED_HOSTS[0]` (Matrix IDs conventionally use the bare site domain even when the client-server API itself lives on a subdomain, via `.well-known` delegation), with an explicit env override for deployments where that doesn't hold.
- Exposed the computed default via a new read-only `matrix_default_id` field on `NotificationPreferenceMeSerializer`, and updated the frontend to prefill from that instead of the raw username.
- Regenerated the affected TypeScript types by hand (no live backend available to run `npm run types:openapi` in this session) — worth a real regen once deployed.

## Test plan
- [x] `uv run pytest bubble/notifications/` (excluding an unrelated pre-existing `test_push_api.py` failure caused by a Python 3.14rc2/pydantic incompatibility in this sandbox) — 55 passed
- [x] `ruff check` on all changed backend files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY7oR6Mp1EavH3ZxWQYDb4)_