### PR TITLE
fix(bookings): stop past confirmed bookings from being cancelled

### DIFF
--- a/backend/bubble/bookings/api/serializers.py
+++ b/backend/bubble/bookings/api/serializers.py
@@ -152,7 +152,7 @@ class BookingSerializer(serializers.ModelSerializer):
             and self.instance.status
             in (BookingStatus.CONFIRMED, BookingStatus.IN_PROGRESS)
             and self.instance.time_to
-            and self.instance.time_to < timezone.now()
+            and self.instance.time_to <= timezone.now()
         ):
             msg = _("This booking has already ended and can no longer be cancelled.")
             raise serializers.ValidationError(msg)

--- a/backend/bubble/bookings/api/serializers.py
+++ b/backend/bubble/bookings/api/serializers.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -138,6 +139,22 @@ class BookingSerializer(serializers.ModelSerializer):
         """
         if self.instance and value == BookingStatus.IN_PROGRESS:
             msg = _("Use the confirm-received action to start a rental.")
+            raise serializers.ValidationError(msg)
+
+        # A confirmed/in-progress booking whose rental period has already ended
+        # actually happened - cancelling it after the fact wouldn't undo
+        # anything and would misrepresent what took place. A still-pending
+        # request that simply timed out without ever being accepted is
+        # unaffected: cancelling it is how a stale request gets cleared out.
+        if (
+            self.instance
+            and value == BookingStatus.CANCELLED
+            and self.instance.status
+            in (BookingStatus.CONFIRMED, BookingStatus.IN_PROGRESS)
+            and self.instance.time_to
+            and self.instance.time_to < timezone.now()
+        ):
+            msg = _("This booking has already ended and can no longer be cancelled.")
             raise serializers.ValidationError(msg)
 
         user = self.context["request"].user

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1896,6 +1896,23 @@ class BookingPastCancelValidationTestCase(APITestCase):
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CONFIRMED
 
+    def test_owner_cannot_cancel_past_in_progress_booking(self):
+        """The item owner cannot cancel an IN_PROGRESS booking once time_to
+        has passed - it should be completed via confirm_returned instead."""
+        booking = self._booking(
+            BookingStatus.IN_PROGRESS, timezone.now() - timedelta(days=1)
+        )
+        self.client.force_authenticate(user=self.item_owner)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CANCELLED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.IN_PROGRESS
+
     def test_can_cancel_confirmed_booking_still_in_window(self):
         """A CONFIRMED booking can still be cancelled before time_to passes."""
         booking = self._booking(

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1835,3 +1835,97 @@ class BookingFulfillmentTestCase(APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CONFIRMED
+
+
+class BookingPastCancelValidationTestCase(APITestCase):
+    """A booking whose rental period has already ended can no longer be
+    cancelled - only a still-open (or never-confirmed) booking can be."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.default_group, _ = Group.objects.get_or_create(name=DefaultGroup.DEFAULT)
+
+        self.item_owner = UserFactory()
+        self.item_owner.groups.add(self.default_group)
+
+        self.booking_user = UserFactory()
+        self.booking_user.groups.add(self.default_group)
+
+        self.item = ItemFactory(
+            user=self.item_owner, sales_type=SalesType.RENT, price="10.00"
+        )
+
+    def _booking(self, booking_status, time_to):
+        return BookingFactory(
+            user=self.booking_user,
+            item=self.item,
+            status=booking_status,
+            time_from=time_to - timedelta(hours=2),
+            time_to=time_to,
+        )
+
+    def test_booker_cannot_cancel_past_confirmed_booking(self):
+        """The booker cannot cancel a CONFIRMED booking once time_to has passed."""
+        booking = self._booking(
+            BookingStatus.CONFIRMED, timezone.now() - timedelta(days=1)
+        )
+        self.client.force_authenticate(user=self.booking_user)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CANCELLED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.CONFIRMED
+
+    def test_owner_cannot_cancel_past_confirmed_booking(self):
+        """The item owner cannot cancel a CONFIRMED booking once time_to has passed."""
+        booking = self._booking(
+            BookingStatus.CONFIRMED, timezone.now() - timedelta(days=1)
+        )
+        self.client.force_authenticate(user=self.item_owner)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CANCELLED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.CONFIRMED
+
+    def test_can_cancel_confirmed_booking_still_in_window(self):
+        """A CONFIRMED booking can still be cancelled before time_to passes."""
+        booking = self._booking(
+            BookingStatus.CONFIRMED, timezone.now() + timedelta(days=1)
+        )
+        self.client.force_authenticate(user=self.booking_user)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CANCELLED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.CANCELLED
+
+    def test_can_cancel_past_pending_booking(self):
+        """A never-confirmed PENDING request stays cancellable after its
+        requested window has passed - that's how a stale request gets
+        cleared out."""
+        booking = self._booking(
+            BookingStatus.PENDING, timezone.now() - timedelta(days=1)
+        )
+        self.client.force_authenticate(user=self.booking_user)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CANCELLED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.CANCELLED

--- a/frontend/src/components/bookings/BookingConversationPanel.tsx
+++ b/frontend/src/components/bookings/BookingConversationPanel.tsx
@@ -429,6 +429,10 @@ const BookingConversationPanel = ({ bookingId, onBack }: BookingConversationPane
             const isRental = salesType === 'rent' || salesType === 'borrow';
             const showConfirmReceived =
               isBuyer && (isSale || (isRental && !selectedItemDetails?.rental_self_service));
+            // Once the rental period has ended there's nothing left to cancel -
+            // cancelling it now wouldn't undo anything that already happened.
+            const isPast =
+              !!selectedBooking.time_to && new Date(selectedBooking.time_to) < new Date();
 
             return (
               <div className="flex items-center gap-2 mt-4">
@@ -443,22 +447,26 @@ const BookingConversationPanel = ({ bookingId, onBack }: BookingConversationPane
                       : t('requests.confirmReceived')}
                   </Button>
                 )}
-                <Button
-                  variant="outline"
-                  onClick={async () => {
-                    try {
-                      await updateBookingMutation.mutateAsync({
-                        id: selectedBooking.id,
-                        data: { status: 2 }, // Cancelled
-                      });
-                    } catch (error) {
-                      console.error('Error cancelling booking:', error);
-                    }
-                  }}
-                  disabled={updateBookingMutation.isPending}
-                >
-                  {updateBookingMutation.isPending ? t('common.submitting') : t('requests.cancel')}
-                </Button>
+                {!isPast && (
+                  <Button
+                    variant="outline"
+                    onClick={async () => {
+                      try {
+                        await updateBookingMutation.mutateAsync({
+                          id: selectedBooking.id,
+                          data: { status: 2 }, // Cancelled
+                        });
+                      } catch (error) {
+                        console.error('Error cancelling booking:', error);
+                      }
+                    }}
+                    disabled={updateBookingMutation.isPending}
+                  >
+                    {updateBookingMutation.isPending
+                      ? t('common.submitting')
+                      : t('requests.cancel')}
+                  </Button>
+                )}
 
                 <div className="ml-auto">
                   <ActionIcon

--- a/frontend/src/components/bookings/BookingConversationPanel.tsx
+++ b/frontend/src/components/bookings/BookingConversationPanel.tsx
@@ -432,7 +432,7 @@ const BookingConversationPanel = ({ bookingId, onBack }: BookingConversationPane
             // Once the rental period has ended there's nothing left to cancel -
             // cancelling it now wouldn't undo anything that already happened.
             const isPast =
-              !!selectedBooking.time_to && new Date(selectedBooking.time_to) < new Date();
+              !!selectedBooking.time_to && new Date(selectedBooking.time_to) <= new Date();
 
             return (
               <div className="flex items-center gap-2 mt-4">


### PR DESCRIPTION
## Summary

A confirmed (or in-progress) booking whose rental period had already ended could still be cancelled by either party:

- **API**: `BookingSerializer.validate_status` had no check on the booking's timing — a plain `PATCH {"status": 2}` (Cancelled) was accepted for a `CONFIRMED`/`IN_PROGRESS` booking no matter how long ago `time_to` had passed.
- **Frontend**: the conversation panel's Cancel button for a confirmed booking was always rendered, regardless of `time_to`.

Cancelling a booking after its rental period already happened doesn't undo anything and misrepresents what actually took place — it should no longer be possible once the booking is in the past.

## Changes

- `backend/bubble/bookings/api/serializers.py`: `validate_status` now rejects a transition to `CANCELLED` when the booking is `CONFIRMED` or `IN_PROGRESS` **and** `time_to` has already passed, with a clear validation message.
- `frontend/src/components/bookings/BookingConversationPanel.tsx`: the Cancel button for a confirmed booking is now hidden once `time_to` has passed.
- A still-**pending** request that simply timed out without ever being confirmed is intentionally **not** affected — cancelling it is exactly how a stale, never-accepted request gets cleared out, so that stays possible regardless of how much time has passed.

## Testing

- `backend/bubble/bookings/tests/tests.py`: added `BookingPastCancelValidationTestCase` covering:
  - booker cannot cancel a past `CONFIRMED` booking
  - owner cannot cancel a past `CONFIRMED` booking
  - a `CONFIRMED` booking still within its window can be cancelled
  - a past **pending** booking can still be cancelled
- `uv run ruff check` / `ruff format --check` on the touched backend files — clean.
- Frontend: `npm run typecheck`, `npx eslint`, `npx prettier --check` on the touched file — all clean.
- Could not run the Django test suite end-to-end in this sandbox: a local Postgres/Redis were stood up, but `google-genai`'s pydantic models fail to import under the sandbox's only available Python 3.14 build (`3.14.0rc2`), which is unrelated to this change — the same failure reproduces on pre-existing, already-passing tests (e.g. `BookingFulfillmentTestCase::test_buyer_cannot_patch_status_to_completed`) that don't touch this code at all. The real CI `pytest` job builds against `python:3.14-slim` (a proper stable release), which doesn't hit this. Verified the new tests are syntactically and semantically correct by direct review and by importing the serializer module standalone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VsZB6Tx5dsFeXJX3RdtXYB)_