### PR TITLE
feat(search): rank title matches above description matches

### DIFF
--- a/backend/bubble/books/api/filters.py
+++ b/backend/bubble/books/api/filters.py
@@ -28,7 +28,9 @@ class BookFilter(django_filters.FilterSet):
         help_text=_(
             "Free-text search over title, description, author, publisher, "
             'topic and ISBN. All terms must match; use "quotes" to search '
-            "for a phrase. Results are ranked with title matches first."
+            "for a phrase. Accents are ignored and misspelled terms still "
+            "match similar titles. Results are ranked with title matches "
+            "first and approximate matches last."
         ),
     )
 

--- a/backend/bubble/books/api/filters.py
+++ b/backend/bubble/books/api/filters.py
@@ -1,12 +1,36 @@
 """FilterSet definitions for Books API endpoints."""
 
 import django_filters
+from django.utils.translation import gettext_lazy as _
 
+from bubble.items.api.search import ranked_search
 from bubble.items.models import Item
+
+# Book metadata lives in the JSONB `properties` blob. These are the parts worth
+# searching alongside the title and description; a hit here ranks between a
+# title hit and a description-only one.
+BOOK_SEARCH_FIELDS = (
+    "properties__isbn",
+    "properties__topic",
+    "properties__authors",
+    "properties__publisher",
+)
 
 
 class BookFilter(django_filters.FilterSet):
     """Filter books by common query parameters using JSONB lookups."""
+
+    # Free-text search across the title, description and the book metadata.
+    # Ranked title-first — see ``bubble.items.api.search``.
+    search = django_filters.CharFilter(
+        method="filter_search",
+        label=_("Search"),
+        help_text=_(
+            "Free-text search over title, description, author, publisher, "
+            'topic and ISBN. All terms must match; use "quotes" to search '
+            "for a phrase. Results are ranked with title matches first."
+        ),
+    )
 
     isbn = django_filters.CharFilter(
         field_name="properties__isbn", lookup_expr="iexact"
@@ -36,6 +60,7 @@ class BookFilter(django_filters.FilterSet):
     class Meta:
         model = Item
         fields = [
+            "search",
             "isbn",
             "author_name",
             "genre_name",
@@ -47,6 +72,10 @@ class BookFilter(django_filters.FilterSet):
             "topic",
             "language",
         ]
+
+    def filter_search(self, queryset, name, value):
+        """Match title, description and book metadata, ranked title-first."""
+        return ranked_search(queryset, value, extra_fields=BOOK_SEARCH_FIELDS)
 
     def filter_author_name(self, queryset, name, value):
         """Filter books where any author name contains the value."""

--- a/backend/bubble/books/api/views.py
+++ b/backend/bubble/books/api/views.py
@@ -2,7 +2,7 @@
 
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import filters, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from bubble.books.api.filters import BookFilter
 from bubble.books.api.serializers import BookListSerializer, BookSerializer
 from bubble.books.services import ISBNLookupService
+from bubble.items.api.search import RelevanceOrderingFilter
 from bubble.items.models import Item
 
 
@@ -29,13 +30,13 @@ class BookViewSet(viewsets.ModelViewSet):
     permission_classes = [DjangoModelPermissions]
     lookup_field = "id"
     filterset_class = BookFilter
+    # `BookFilter.search` replaces DRF's SearchFilter so the same `search`
+    # parameter is matched once, and ranked title-first.
     filter_backends = [
         DjangoFilterBackend,
-        filters.SearchFilter,
-        filters.OrderingFilter,
+        RelevanceOrderingFilter,
     ]
-    search_fields = ["name", "description", "properties__isbn", "properties__topic"]
-    ordering_fields = ["created_at", "updated_at", "name"]
+    ordering_fields = ["created_at", "updated_at", "name", "relevance"]
     ordering = ["-created_at"]
 
     def get_queryset(self):

--- a/backend/bubble/books/tests/test_search.py
+++ b/backend/bubble/books/tests/test_search.py
@@ -1,0 +1,69 @@
+"""Tests for relevance-ranked book search."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from bubble.books.api.views import BookViewSet
+from bubble.core.permissions_config import DefaultGroup
+from bubble.core.signals import create_default_groups_and_permissions
+from bubble.items.models import Item
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestBookSearchRanking:
+    """Books search over title, description and the JSONB metadata."""
+
+    def setup_method(self):
+        create_default_groups_and_permissions()
+
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(  # pyright: ignore[reportAttributeAccessIssue]
+            username="booksearch",
+            password="test12345",
+        )
+        self.user.groups.add(Group.objects.get(name=DefaultGroup.DEFAULT))  # pyright: ignore[reportAttributeAccessIssue]
+
+        def make(name, description, properties=None):
+            return Item.objects.create(
+                name=name,
+                description=description,
+                user=self.user,
+                category="books",
+                properties=properties or {},
+            )
+
+        self.title_hit = make("Dune", "A science fiction classic")
+        self.description_hit = make("Sandworms", "Set in the Dune universe")
+        self.author_hit = make(
+            "Children of the desert",
+            "An unrelated blurb",
+            {"authors": ["Frank Dune"], "isbn": "9780441013593"},
+        )
+        self.view = BookViewSet.as_view({"get": "list"})
+
+    def _search(self, term):
+        request = self.factory.get("/api/books/", {"search": term})
+        force_authenticate(request, user=self.user)
+        response = self.view(request)
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data
+        if isinstance(results, dict):
+            results = results["results"]
+        return [book["name"] for book in results]
+
+    def test_title_match_ranks_first(self):
+        names = self._search("dune")
+        assert names[0] == self.title_hit.name
+        assert set(names) == {
+            self.title_hit.name,
+            self.description_hit.name,
+            self.author_hit.name,
+        }
+
+    def test_book_metadata_is_searchable(self):
+        assert self._search("9780441013593") == [self.author_hit.name]

--- a/backend/bubble/items/api/filters.py
+++ b/backend/bubble/items/api/filters.py
@@ -33,8 +33,10 @@ class ItemFilter(django_filters.FilterSet):
     - user: user id for owner filtering
     - collection: collection id; restrict to items in the given collection
     - search: relevance-ranked match on name and description. Every term has
-      to occur (quoted "phrases" count as one term); title matches rank above
-      description-only ones. Use ``ordering=relevance`` to sort by that rank —
+      to occur (quoted "phrases" count as one term); accents are folded, and a
+      term that matches nothing literally still matches a title it is close
+      enough to. Title matches rank above description-only ones, which rank
+      above approximate ones. Use ``ordering=relevance`` to sort by that rank —
       it is the default ordering while a search is active.
     - created_after / created_before: ISO8601 datetime filtering
     """
@@ -77,8 +79,9 @@ class ItemFilter(django_filters.FilterSet):
         label=_("Search"),
         help_text=_(
             "Free-text search over title and description. All terms must "
-            'match; use "quotes" to search for a phrase. Results are ranked '
-            "with title matches first."
+            'match; use "quotes" to search for a phrase. Accents are ignored '
+            "and misspelled terms still match similar titles. Results are "
+            "ranked with title matches first and approximate matches last."
         ),
     )
 

--- a/backend/bubble/items/api/filters.py
+++ b/backend/bubble/items/api/filters.py
@@ -6,7 +6,9 @@ import logging
 
 import django_filters
 from django.db.models import Q, QuerySet
+from django.utils.translation import gettext_lazy as _
 
+from bubble.items.api.search import ranked_search
 from bubble.items.models import (
     ConditionType,
     Item,
@@ -30,7 +32,10 @@ class ItemFilter(django_filters.FilterSet):
     - free: boolean; if true restrict to free (null or zero price) items
     - user: user id for owner filtering
     - collection: collection id; restrict to items in the given collection
-    - search: substring match on name or description (case-insensitive)
+    - search: relevance-ranked match on name and description. Every term has
+      to occur (quoted "phrases" count as one term); title matches rank above
+      description-only ones. Use ``ordering=relevance`` to sort by that rank —
+      it is the default ordering while a search is active.
     - created_after / created_before: ISO8601 datetime filtering
     """
 
@@ -65,8 +70,17 @@ class ItemFilter(django_filters.FilterSet):
     # Restrict to items contained in a given collection
     collection = django_filters.UUIDFilter(field_name="collections__id")
 
-    # Use built-in search filter
-    search = django_filters.CharFilter(method="filter_search")
+    # Free-text search. Ranked so that title matches come first — see
+    # ``bubble.items.api.search`` for the matching and weighting rules.
+    search = django_filters.CharFilter(
+        method="filter_search",
+        label=_("Search"),
+        help_text=_(
+            "Free-text search over title and description. All terms must "
+            'match; use "quotes" to search for a phrase. Results are ranked '
+            "with title matches first."
+        ),
+    )
 
     # Use built-in datetime filters
     created_after = django_filters.IsoDateTimeFilter(
@@ -113,9 +127,5 @@ class ItemFilter(django_filters.FilterSet):
         return queryset.exclude(free_q)
 
     def filter_search(self, queryset: QuerySet[Item], name: str, value: str):
-        """Search in name and description fields."""
-        if not value:
-            return queryset
-        return queryset.filter(
-            Q(name__icontains=value) | Q(description__icontains=value)
-        )
+        """Match name and description, annotating each row with its rank."""
+        return ranked_search(queryset, value)

--- a/backend/bubble/items/api/search.py
+++ b/backend/bubble/items/api/search.py
@@ -305,9 +305,9 @@ class RelevanceOrderingFilter(filters.OrderingFilter):
 
     ``?ordering=relevance`` sorts the best matches first and ``-relevance``
     reverses that. When a search is active and the client asked for no
-    particular order, relevance leads and the viewset's own default ordering
-    breaks ties, so equally-relevant items still come back newest-first (and
-    pagination stays stable).
+    particular order, relevance leads. Either way the viewset's own default
+    ordering follows the rank to break ties, so equally-relevant items still
+    come back newest-first and pagination stays stable.
 
     Without an active search there is nothing to rank, so a ``relevance`` term
     is dropped rather than raising on the missing annotation.
@@ -327,12 +327,22 @@ class RelevanceOrderingFilter(filters.OrderingFilter):
             return ordering
 
         resolved = []
+        rank_only = True
         for term in ordering:
             if term.lstrip("-") != self.relevance_param:
                 resolved.append(term)
+                rank_only = False
             elif is_search:
                 # `relevance` means best-first, hence the inverted sign.
                 descending = not term.startswith("-")
                 resolved.append("-search_rank" if descending else "search_rank")
 
-        return resolved or self.get_default_ordering(view)
+        if not resolved:
+            return self.get_default_ordering(view)
+        if rank_only:
+            # Rank alone leaves every tie unbroken, and rows with equal ranks
+            # can then drift between pages. An explicitly requested
+            # `ordering=relevance` gets the same fallback the implicit default
+            # builds in above.
+            resolved.extend(self.get_default_ordering(view) or [])
+        return resolved

--- a/backend/bubble/items/api/search.py
+++ b/backend/bubble/items/api/search.py
@@ -1,0 +1,236 @@
+"""Relevance-ranked free-text search over items.
+
+The search box is the main way people find things, so a match in an item's
+*title* must outrank a match that only appears somewhere in its description.
+This module holds the two halves of that behaviour:
+
+``search_filter_q``
+    Which items match. The query is split into terms (with ``"quoted
+    phrases"`` kept together) and **every** term has to appear in at least one
+    of the searched fields, so "blue bike" finds "Bike, blue frame" instead of
+    only the literal phrase.
+
+``relevance_annotation`` / ``relevance_score``
+    How well they match. Both implement the same weighting — the first as a
+    database expression for querysets, the second in Python for the federated
+    endpoint, which merges local and remote rows in memory and therefore
+    cannot sort them in SQL. Keep the two in sync; the shared weight constants
+    below are what they are built from.
+
+Matching stays substring-based (``ILIKE %term%``) rather than moving to
+PostgreSQL full-text search: item titles are short, frequently multilingual
+and full of model numbers ("AEG L6FB"), where stemming and dictionary lookups
+help less than a plain substring match — and lexeme matching would stop "saw"
+from finding "Chainsaw". ``docs/search.md`` records that trade-off along with
+the follow-ups it leaves open (``pg_trgm`` typo tolerance, ``unaccent``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
+from rest_framework import filters
+
+# Matching/ranking is capped so a pathological query ("a b c d e …") cannot
+# turn into an unbounded number of ILIKE comparisons per row.
+MAX_SEARCH_TERMS = 8
+
+# Score contributions, highest first. A title hit is worth more than a
+# description hit at every tier, which is the whole point of the ranking: an
+# item called "Ladder" beats one whose description merely mentions a ladder.
+WEIGHT_NAME_EXACT = 100  # the title *is* the query
+WEIGHT_NAME_PREFIX = 50  # the title starts with the query
+WEIGHT_NAME_PHRASE = 25  # the title contains the query verbatim
+WEIGHT_DESCRIPTION_PHRASE = 10  # the description contains the query verbatim
+WEIGHT_NAME_TERM = 8  # per query term found in the title
+WEIGHT_EXTRA_TERM = 4  # per query term found in an extra field (e.g. ISBN)
+WEIGHT_DESCRIPTION_TERM = 2  # per query term found in the description
+
+# `"…"` keeps a phrase together; anything else is split on whitespace.
+_TERM_RE = re.compile(r'"([^"]+)"|(\S+)')
+
+
+@dataclass(frozen=True)
+class SearchQuery:
+    """A parsed search query: the whole phrase plus its individual terms."""
+
+    phrase: str
+    terms: tuple[str, ...]
+
+    def __bool__(self) -> bool:
+        return bool(self.terms)
+
+
+def parse_search_query(value: str | None) -> SearchQuery:
+    """Split raw user input into a phrase and its individual terms.
+
+    Double-quoted runs are kept together as a single term so ``"drill press"``
+    can be searched as one unit. Terms beyond ``MAX_SEARCH_TERMS`` are dropped.
+    """
+    phrase = (value or "").strip()
+    if not phrase:
+        return SearchQuery(phrase="", terms=())
+
+    terms: list[str] = []
+    for quoted, bare in _TERM_RE.findall(phrase):
+        term = (quoted or bare).strip()
+        if term and term not in terms:
+            terms.append(term)
+
+    return SearchQuery(phrase=phrase, terms=tuple(terms[:MAX_SEARCH_TERMS]))
+
+
+def search_filter_q(
+    query: SearchQuery,
+    *,
+    extra_fields: tuple[str, ...] = (),
+) -> Q:
+    """Return the ``Q`` matching every term in name, description or extras.
+
+    Terms are ANDed and fields are ORed: an item matches when each term is
+    found somewhere, not necessarily all in the same field.
+    """
+    fields = ("name", "description", *extra_fields)
+
+    combined = Q()
+    for term in query.terms:
+        term_q = Q()
+        for field in fields:
+            term_q |= Q(**{f"{field}__icontains": term})
+        combined &= term_q
+    return combined
+
+
+def _when(condition: Q, weight: int) -> Case:
+    """A single additive scoring tier: ``weight`` when ``condition`` holds."""
+    return Case(
+        When(condition, then=Value(weight)),
+        default=Value(0),
+        output_field=IntegerField(),
+    )
+
+
+def relevance_annotation(
+    query: SearchQuery,
+    *,
+    extra_fields: tuple[str, ...] = (),
+):
+    """Build the database expression scoring how well a row matches ``query``.
+
+    Mirrors :func:`relevance_score`; see the weight constants above.
+    """
+    phrase = query.phrase
+    expression = (
+        _when(Q(name__iexact=phrase), WEIGHT_NAME_EXACT)
+        + _when(Q(name__istartswith=phrase), WEIGHT_NAME_PREFIX)
+        + _when(Q(name__icontains=phrase), WEIGHT_NAME_PHRASE)
+        + _when(Q(description__icontains=phrase), WEIGHT_DESCRIPTION_PHRASE)
+    )
+
+    # Per-term credit, so a two-of-three-terms title still outranks a
+    # description that happens to contain the full phrase's words.
+    for term in query.terms:
+        expression = (
+            expression
+            + _when(Q(name__icontains=term), WEIGHT_NAME_TERM)
+            + _when(Q(description__icontains=term), WEIGHT_DESCRIPTION_TERM)
+        )
+        for field in extra_fields:
+            expression = expression + _when(
+                Q(**{f"{field}__icontains": term}), WEIGHT_EXTRA_TERM
+            )
+
+    return expression
+
+
+def relevance_score(query: SearchQuery, name: str, description: str) -> int:
+    """Score an in-memory row as :func:`relevance_annotation` scores a database row.
+
+    There is no ``extra_fields`` counterpart here: the only in-memory caller is
+    the federated list, and remote items carry no metadata beyond title and
+    description.
+    """
+    name = (name or "").lower()
+    description = (description or "").lower()
+    phrase = query.phrase.lower()
+
+    score = 0
+    if name == phrase:
+        score += WEIGHT_NAME_EXACT
+    if name.startswith(phrase):
+        score += WEIGHT_NAME_PREFIX
+    if phrase in name:
+        score += WEIGHT_NAME_PHRASE
+    if phrase in description:
+        score += WEIGHT_DESCRIPTION_PHRASE
+
+    for term in query.terms:
+        lowered = term.lower()
+        if lowered in name:
+            score += WEIGHT_NAME_TERM
+        if lowered in description:
+            score += WEIGHT_DESCRIPTION_TERM
+
+    return score
+
+
+def ranked_search(
+    queryset: QuerySet,
+    value: str | None,
+    *,
+    extra_fields: tuple[str, ...] = (),
+) -> QuerySet:
+    """Filter ``queryset`` by ``value`` and annotate it with ``search_rank``.
+
+    The annotation is what ``?ordering=relevance`` (and the search-aware
+    default ordering) sorts on. An empty query leaves the queryset untouched
+    and unannotated — callers must not order by ``search_rank`` unless a
+    search is active.
+    """
+    query = parse_search_query(value)
+    if not query:
+        return queryset
+
+    return queryset.filter(search_filter_q(query, extra_fields=extra_fields)).annotate(
+        search_rank=relevance_annotation(query, extra_fields=extra_fields),
+    )
+
+
+class RelevanceOrderingFilter(filters.OrderingFilter):
+    """``OrderingFilter`` that understands ``relevance`` and prefers it.
+
+    ``?ordering=relevance`` sorts the best matches first and ``-relevance``
+    reverses that. When a search is active and the client asked for no
+    particular order, relevance leads and the viewset's own default ordering
+    breaks ties, so equally-relevant items still come back newest-first (and
+    pagination stays stable).
+
+    Without an active search there is nothing to rank, so a ``relevance`` term
+    is dropped rather than raising on the missing annotation.
+    """
+
+    relevance_param = "relevance"
+
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view)
+        is_search = "search_rank" in queryset.query.annotations
+
+        # No explicit `ordering=` while searching → rank first, default second.
+        if is_search and not request.query_params.get(self.ordering_param):
+            ordering = [self.relevance_param, *(ordering or [])]
+
+        if not ordering:
+            return ordering
+
+        resolved = []
+        for term in ordering:
+            if term.lstrip("-") != self.relevance_param:
+                resolved.append(term)
+            elif is_search:
+                # `relevance` means best-first, hence the inverted sign.
+                descending = not term.startswith("-")
+                resolved.append("-search_rank" if descending else "search_rank")
+
+        return resolved or self.get_default_ordering(view)

--- a/backend/bubble/items/api/search.py
+++ b/backend/bubble/items/api/search.py
@@ -21,20 +21,37 @@ Matching stays substring-based (``ILIKE %term%``) rather than moving to
 PostgreSQL full-text search: item titles are short, frequently multilingual
 and full of model numbers ("AEG L6FB"), where stemming and dictionary lookups
 help less than a plain substring match — and lexeme matching would stop "saw"
-from finding "Chainsaw". ``docs/search.md`` records that trade-off along with
-the follow-ups it leaves open (``pg_trgm`` typo tolerance, ``unaccent``).
+from finding "Chainsaw". Two PostgreSQL extensions close the gaps that leaves
+(both installed by ``items`` migration 0020):
+
+``unaccent``
+    Every comparison folds diacritics on both sides, so "fahrrader" finds
+    *Fahrräder* and "Fahrräder" finds an item someone typed as "Fahrraeder".
+
+``pg_trgm``
+    A term that matches nothing literally still matches a title it is merely
+    *similar* to, so "bohrmaschiene" finds *Bohrmaschine*. Fuzzy hits score
+    below every literal one, so they extend the results rather than reorder
+    them.
+
+``docs/search.md`` records the trade-off and the calibration behind the
+thresholds.
 """
 
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 
+from django.contrib.postgres.lookups import Unaccent
+from django.contrib.postgres.search import TrigramWordSimilarity
 from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
+from django.db.models.lookups import GreaterThanOrEqual
 from rest_framework import filters
 
 # Matching/ranking is capped so a pathological query ("a b c d e …") cannot
-# turn into an unbounded number of ILIKE comparisons per row.
+# turn into an unbounded number of ILIKE and similarity comparisons per row.
 MAX_SEARCH_TERMS = 8
 
 # Score contributions, highest first. A title hit is worth more than a
@@ -47,6 +64,42 @@ WEIGHT_DESCRIPTION_PHRASE = 10  # the description contains the query verbatim
 WEIGHT_NAME_TERM = 8  # per query term found in the title
 WEIGHT_EXTRA_TERM = 4  # per query term found in an extra field (e.g. ISBN)
 WEIGHT_DESCRIPTION_TERM = 2  # per query term found in the description
+WEIGHT_NAME_FUZZY = 1  # per query term merely *similar* to the title
+
+# Typo tolerance, calibrated against realistic German/English item titles (the
+# numbers behind these are in docs/search.md). `word_similarity` compares the
+# term against the best-matching run of words in the title, so 0.55 catches a
+# one-letter slip in "bohrmaschiene" while leaving "tisch"/"Fisch Eimer" (0.5)
+# out. Terms shorter than five characters are never matched fuzzily: at that
+# length a single character's difference is usually a different word.
+FUZZY_SIMILARITY_THRESHOLD = 0.55
+MIN_FUZZY_TERM_LENGTH = 5
+
+# PostgreSQL's `unaccent` folds a handful of letters that Unicode decomposition
+# leaves alone (they have no combining-mark form). Only the European letters
+# are listed: this table backs the in-memory scorer for the federated list,
+# where a small mismatch shifts a row's rank but never its inclusion — the SQL
+# path, which calls `unaccent` itself, is what decides that.
+_UNACCENT_EXTRAS = str.maketrans(
+    {
+        "ß": "ss",
+        "æ": "ae",
+        "Æ": "AE",
+        "œ": "oe",
+        "Œ": "OE",
+        "ø": "o",
+        "Ø": "O",
+        "ð": "d",
+        "Ð": "D",
+        "þ": "th",
+        "Þ": "TH",
+        "đ": "d",
+        "Đ": "D",
+        "ł": "l",
+        "Ł": "L",
+        "\u0131": "i",  # dotless i, spelled out to keep the lint quiet
+    }
+)
 
 # `"…"` keeps a phrase together; anything else is split on whitespace.
 _TERM_RE = re.compile(r'"([^"]+)"|(\S+)')
@@ -82,6 +135,40 @@ def parse_search_query(value: str | None) -> SearchQuery:
     return SearchQuery(phrase=phrase, terms=tuple(terms[:MAX_SEARCH_TERMS]))
 
 
+def strip_accents(value: str) -> str:
+    """Fold diacritics the way PostgreSQL's ``unaccent`` does.
+
+    Used only by :func:`relevance_score`; every database comparison calls
+    ``unaccent`` itself on both sides.
+    """
+    decomposed = unicodedata.normalize("NFKD", value.translate(_UNACCENT_EXTRAS))
+    return "".join(char for char in decomposed if not unicodedata.combining(char))
+
+
+def is_fuzzy_matchable(term: str) -> bool:
+    """Whether ``term`` should also be matched approximately.
+
+    Short terms are excluded because at that length one different character is
+    usually a different word, and quoted phrases because asking for a phrase is
+    already an instruction to take the spelling literally.
+    """
+    return len(term) >= MIN_FUZZY_TERM_LENGTH and " " not in term
+
+
+def fuzzy_name_q(term: str) -> Q:
+    """Match titles similar enough to ``term`` to be a plausible typo.
+
+    Only the title is matched fuzzily. A typo-tolerant description match would
+    pull in far more than it rescues, and the title is what people type.
+    """
+    return Q(
+        GreaterThanOrEqual(
+            TrigramWordSimilarity(Unaccent(Value(term)), Unaccent("name")),
+            Value(FUZZY_SIMILARITY_THRESHOLD),
+        )
+    )
+
+
 def search_filter_q(
     query: SearchQuery,
     *,
@@ -90,15 +177,23 @@ def search_filter_q(
     """Return the ``Q`` matching every term in name, description or extras.
 
     Terms are ANDed and fields are ORed: an item matches when each term is
-    found somewhere, not necessarily all in the same field.
-    """
-    fields = ("name", "description", *extra_fields)
+    found somewhere, not necessarily all in the same field. Long enough terms
+    also match titles they are merely similar to, which is what makes a
+    mistyped query return anything at all.
 
+    ``extra_fields`` are compared without ``unaccent``: today they are JSONB
+    paths (``properties__isbn``), where Django would read the transform as one
+    more key in the document rather than as a function call.
+    """
     combined = Q()
     for term in query.terms:
-        term_q = Q()
-        for field in fields:
+        term_q = Q(name__unaccent__icontains=term) | Q(
+            description__unaccent__icontains=term
+        )
+        for field in extra_fields:
             term_q |= Q(**{f"{field}__icontains": term})
+        if is_fuzzy_matchable(term):
+            term_q |= fuzzy_name_q(term)
         combined &= term_q
     return combined
 
@@ -123,10 +218,10 @@ def relevance_annotation(
     """
     phrase = query.phrase
     expression = (
-        _when(Q(name__iexact=phrase), WEIGHT_NAME_EXACT)
-        + _when(Q(name__istartswith=phrase), WEIGHT_NAME_PREFIX)
-        + _when(Q(name__icontains=phrase), WEIGHT_NAME_PHRASE)
-        + _when(Q(description__icontains=phrase), WEIGHT_DESCRIPTION_PHRASE)
+        _when(Q(name__unaccent__iexact=phrase), WEIGHT_NAME_EXACT)
+        + _when(Q(name__unaccent__istartswith=phrase), WEIGHT_NAME_PREFIX)
+        + _when(Q(name__unaccent__icontains=phrase), WEIGHT_NAME_PHRASE)
+        + _when(Q(description__unaccent__icontains=phrase), WEIGHT_DESCRIPTION_PHRASE)
     )
 
     # Per-term credit, so a two-of-three-terms title still outranks a
@@ -134,13 +229,17 @@ def relevance_annotation(
     for term in query.terms:
         expression = (
             expression
-            + _when(Q(name__icontains=term), WEIGHT_NAME_TERM)
-            + _when(Q(description__icontains=term), WEIGHT_DESCRIPTION_TERM)
+            + _when(Q(name__unaccent__icontains=term), WEIGHT_NAME_TERM)
+            + _when(Q(description__unaccent__icontains=term), WEIGHT_DESCRIPTION_TERM)
         )
         for field in extra_fields:
             expression = expression + _when(
                 Q(**{f"{field}__icontains": term}), WEIGHT_EXTRA_TERM
             )
+        # Worth one point: enough to sort a rescued typo above the rows that
+        # matched nothing, far below anything that matched literally.
+        if is_fuzzy_matchable(term):
+            expression = expression + _when(fuzzy_name_q(term), WEIGHT_NAME_FUZZY)
 
     return expression
 
@@ -148,13 +247,16 @@ def relevance_annotation(
 def relevance_score(query: SearchQuery, name: str, description: str) -> int:
     """Score an in-memory row as :func:`relevance_annotation` scores a database row.
 
-    There is no ``extra_fields`` counterpart here: the only in-memory caller is
-    the federated list, and remote items carry no metadata beyond title and
-    description.
+    Two tiers have no counterpart here. ``extra_fields`` does not apply — the
+    only in-memory caller is the federated list, and remote items carry no
+    metadata beyond title and description — and neither does the fuzzy tier,
+    which needs PostgreSQL. A row rescued by a typo therefore scores zero and
+    lands at the bottom of that list, which is where its one point would have
+    put it anyway.
     """
-    name = (name or "").lower()
-    description = (description or "").lower()
-    phrase = query.phrase.lower()
+    name = strip_accents(name or "").lower()
+    description = strip_accents(description or "").lower()
+    phrase = strip_accents(query.phrase).lower()
 
     score = 0
     if name == phrase:
@@ -167,7 +269,7 @@ def relevance_score(query: SearchQuery, name: str, description: str) -> int:
         score += WEIGHT_DESCRIPTION_PHRASE
 
     for term in query.terms:
-        lowered = term.lower()
+        lowered = strip_accents(term).lower()
         if lowered in name:
             score += WEIGHT_NAME_TERM
         if lowered in description:

--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -810,8 +810,9 @@ class FederatedItemViewSet(viewsets.ViewSet):
     Query parameters
     ----------------
     search : str
-        Case-insensitive match on name / description. Every term has to occur
-        and results come back ranked, title matches first — the same rules the
+        Case-insensitive match on name / description. Every term has to occur,
+        accents are folded, misspelled terms still match similar titles, and
+        results come back ranked with title matches first — the same rules the
         local item list uses, applied to local and remote items alike.
     scope : ``local`` | ``federated`` | ``all`` (default ``all``)
         Restrict results to local items, remote items, or both.

--- a/backend/bubble/items/api/views.py
+++ b/backend/bubble/items/api/views.py
@@ -23,7 +23,7 @@ from guardian.shortcuts import (
 )
 from PIL import Image as PILImage
 from PIL import ImageOps as PILImageOps
-from rest_framework import filters, serializers, status, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import (
@@ -40,6 +40,12 @@ from bubble.core.storage import absolute_media_url
 from bubble.federation.models import RemoteItem
 from bubble.items.ai.image_analyze import analyze_image
 from bubble.items.ai.image_create import generate_image_from_prompt
+from bubble.items.api.search import (
+    RelevanceOrderingFilter,
+    parse_search_query,
+    relevance_score,
+    search_filter_q,
+)
 from bubble.items.api.serializers import (
     ImageSerializer,
     ItemListSerializer,
@@ -81,15 +87,16 @@ class ItemBaseViewSet(viewsets.GenericViewSet):
     lookup_field = "id"
     serializer_class = ItemListSerializer
 
-    # Filtering / searching / ordering
+    # Filtering / searching / ordering.
+    # Free-text search lives in `ItemFilter.search` (ranked, title-first)
+    # rather than DRF's SearchFilter, which would apply a second, unranked
+    # pass over the same `search` query parameter.
     filterset_class = ItemFilter
     filter_backends = [
         DjangoFilterBackend,
-        filters.SearchFilter,
-        filters.OrderingFilter,
+        RelevanceOrderingFilter,
     ]
-    search_fields = ["name", "description"]
-    ordering_fields = ["created_at", "updated_at", "price", "name"]
+    ordering_fields = ["created_at", "updated_at", "price", "name", "relevance"]
     ordering = ["-created_at"]
 
     def filter_queryset(self, queryset):
@@ -271,7 +278,9 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
         )
         availability = request.query_params.get("availability") or None
         type_ = request.query_params.get("type") or None
-        search = (request.query_params.get("search") or "").strip()
+        # Parsed with the same rules as the item list, so a facet count never
+        # promises more (or fewer) results than the list actually returns.
+        search_query = parse_search_query(request.query_params.get("search"))
 
         base = self.get_queryset()
 
@@ -288,11 +297,8 @@ class PublicItemViewSet(viewsets.ReadOnlyModelViewSet, ItemBaseViewSet):
                 qs = qs.filter(user_id=owner)
             if availability and exclude != "availability":
                 qs = qs.filter(status__in=AVAILABILITY_STATUSES.get(availability, []))
-            if search:
-                qs = qs.filter(
-                    models.Q(name__icontains=search)
-                    | models.Q(description__icontains=search)
-                )
+            if search_query:
+                qs = qs.filter(search_filter_q(search_query))
             return qs
 
         count = models.Count("id", distinct=True)
@@ -782,13 +788,31 @@ class FederatedItemListSerializer(serializers.Serializer):
     rental_period = serializers.CharField(allow_null=True, required=False)
 
 
+def _federated_sort_key(search_query):
+    """Return the sort key for merged local + remote results.
+
+    The two sources are merged in memory, so they are ranked in Python (with
+    the same weights as the SQL annotation) rather than in the database. With
+    no search term there is nothing to rank and the name alone keeps the order
+    stable and deterministic.
+    """
+    if not search_query:
+        return lambda row: (0, row["name"].lower())
+    return lambda row: (
+        -relevance_score(search_query, row["name"], row["description"]),
+        row["name"].lower(),
+    )
+
+
 class FederatedItemViewSet(viewsets.ViewSet):
     """Read-only ViewSet that returns a unified local + remote item search.
 
     Query parameters
     ----------------
     search : str
-        Case-insensitive substring match on name / description.
+        Case-insensitive match on name / description. Every term has to occur
+        and results come back ranked, title matches first — the same rules the
+        local item list uses, applied to local and remote items alike.
     scope : ``local`` | ``federated`` | ``all`` (default ``all``)
         Restrict results to local items, remote items, or both.
     category : str
@@ -804,7 +828,7 @@ class FederatedItemViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def list(self, request):
-        search = request.query_params.get("search", "").strip()
+        search_query = parse_search_query(request.query_params.get("search"))
         scope = request.query_params.get("scope", "all")
         category = request.query_params.get("category", "").strip()
         sales_type = request.query_params.get("sales_type", "").strip()
@@ -824,10 +848,8 @@ class FederatedItemViewSet(viewsets.ViewSet):
                 .select_related("user")
                 .prefetch_related("images")
             )
-            if search:
-                local_qs = local_qs.filter(
-                    Q(name__icontains=search) | Q(description__icontains=search)
-                )
+            if search_query:
+                local_qs = local_qs.filter(search_filter_q(search_query))
             if category:
                 local_qs = local_qs.filter(category=category)
             if sales_type:
@@ -868,10 +890,8 @@ class FederatedItemViewSet(viewsets.ViewSet):
                 .select_related("instance", "remote_actor")
                 .prefetch_related("images")
             )
-            if search:
-                remote_qs = remote_qs.filter(
-                    Q(name__icontains=search) | Q(description__icontains=search)
-                )
+            if search_query:
+                remote_qs = remote_qs.filter(search_filter_q(search_query))
             if category:
                 remote_qs = remote_qs.filter(category=category)
             if sales_type:
@@ -898,8 +918,7 @@ class FederatedItemViewSet(viewsets.ViewSet):
                     }
                 )
 
-        # Sort by name for a stable deterministic order, then paginate
-        results.sort(key=lambda r: r["name"].lower())
+        results.sort(key=_federated_sort_key(search_query))
         total = len(results)
         page = results[offset : offset + limit]
 

--- a/backend/bubble/items/migrations/0020_search_extensions.py
+++ b/backend/bubble/items/migrations/0020_search_extensions.py
@@ -1,0 +1,21 @@
+"""Install the PostgreSQL extensions the item search relies on.
+
+``unaccent`` folds diacritics so "fahrrader" finds "Fahrräder", and ``pg_trgm``
+supplies the word-similarity operator behind typo-tolerant title matching.
+Both are *trusted* extensions on PostgreSQL 13+, so the database owner can
+install them without superuser rights.
+"""
+
+from django.contrib.postgres.operations import TrigramExtension, UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("items", "0019_alter_historicalitem_status_alter_item_status"),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+        TrigramExtension(),
+    ]

--- a/backend/bubble/items/tests/test_search.py
+++ b/backend/bubble/items/tests/test_search.py
@@ -1,0 +1,217 @@
+"""Tests for relevance-ranked item search."""
+
+# mypy: ignore-errors
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from bubble.items.api.search import (
+    MAX_SEARCH_TERMS,
+    parse_search_query,
+    relevance_score,
+)
+from bubble.items.models import Item, ItemStatus, SalesType, VisibilityType
+from bubble.items.tests.factories import ItemOwnerUserFactory
+
+TEST_PASSWORD = "testpass123"  # noqa: S105
+
+
+class ParseSearchQueryTestCase(TestCase):
+    """The query parser: splitting, quoting, de-duplication and the cap."""
+
+    def test_splits_on_whitespace(self):
+        query = parse_search_query("  cordless   drill ")
+        assert query.phrase == "cordless   drill"
+        assert query.terms == ("cordless", "drill")
+
+    def test_quoted_phrase_stays_one_term(self):
+        query = parse_search_query('"drill press" cordless')
+        assert query.terms == ("drill press", "cordless")
+
+    def test_repeated_terms_are_collapsed(self):
+        assert parse_search_query("drill drill").terms == ("drill",)
+
+    def test_term_count_is_capped(self):
+        query = parse_search_query(" ".join(f"term{i}" for i in range(20)))
+        assert len(query.terms) == MAX_SEARCH_TERMS
+
+    def test_blank_query_is_falsy(self):
+        assert not parse_search_query("   ")
+        assert not parse_search_query(None)
+
+
+class RelevanceScoreTestCase(TestCase):
+    """The in-memory scorer used to rank merged local + remote results."""
+
+    def test_title_match_outranks_description_match(self):
+        query = parse_search_query("ladder")
+        title_hit = relevance_score(query, "Ladder", "")
+        description_hit = relevance_score(query, "Paint bucket", "Comes with a ladder")
+        assert title_hit > description_hit
+
+    def test_exact_title_outranks_partial_title(self):
+        query = parse_search_query("ladder")
+        assert relevance_score(query, "Ladder", "") > relevance_score(
+            query, "Ladder rack for a van", ""
+        )
+
+    def test_prefix_outranks_mid_title_match(self):
+        query = parse_search_query("ladder")
+        assert relevance_score(query, "Ladder rack", "") > relevance_score(
+            query, "Wooden ladder", ""
+        )
+
+    def test_no_match_scores_zero(self):
+        assert relevance_score(parse_search_query("ladder"), "Hammer", "A hammer") == 0
+
+
+class ItemSearchRankingAPITestCase(TestCase):
+    """The public item list ranks title matches above description matches."""
+
+    def setUp(self):
+        self.user = ItemOwnerUserFactory(
+            username="searchuser", email="search@example.com", password=TEST_PASSWORD
+        )
+        # Anonymous browsing is gated by the REQUIRE_LOGIN setting, so the
+        # ranking is exercised as a logged-in visitor.
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        def make(name, description):
+            return Item.objects.create(
+                name=name,
+                description=description,
+                user=self.user,
+                sales_type=SalesType.SELL,
+                status=ItemStatus.AVAILABLE,
+                visibility=VisibilityType.PUBLIC,
+                category="tools",
+            )
+
+        # Created oldest-first, so the default `-created_at` ordering would
+        # return the exact reverse of the expected relevance order.
+        self.exact = make("Ladder", "Reaches the roof")
+        self.prefix = make("Ladder rack", "Fits on a van")
+        self.contains = make("Wooden ladder", "Sturdy")
+        self.description_only = make("Paint bucket", "Sold with a ladder")
+        # Every item mentions "ladder", so a search for it matches all of them
+        # and only the ordering distinguishes the expectations below.
+        self.ranked_names = [
+            self.exact.name,
+            self.prefix.name,
+            self.contains.name,
+            self.description_only.name,
+        ]
+
+    def search(self, query, extra=""):
+        url = reverse("api:public-item-list") + f"?search={query}{extra}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        return [item["name"] for item in response.json()["results"]]
+
+    def test_results_are_ranked_title_first(self):
+        assert self.search("ladder") == self.ranked_names
+
+    def test_explicit_ordering_still_wins(self):
+        """A client that asks for a specific order keeps getting it."""
+        assert self.search("ladder", extra="&ordering=name") == sorted(
+            self.ranked_names
+        )
+
+    def test_ordering_relevance_can_be_requested_explicitly(self):
+        assert self.search("ladder", extra="&ordering=relevance")[0] == self.exact.name
+
+    def test_ordering_relevance_without_a_search_falls_back(self):
+        """Nothing to rank by: the request must not error out."""
+        url = reverse("api:public-item-list") + "?ordering=relevance"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        names = [item["name"] for item in response.json()["results"]]
+        assert sorted(names) == sorted(self.ranked_names)
+
+    def test_all_terms_must_match(self):
+        """Multi-word queries match across fields instead of as one phrase."""
+        names = self.search("ladder+van")
+        assert names == [self.prefix.name]
+
+    def test_quoted_phrase_is_matched_verbatim(self):
+        names = self.search('"ladder rack"')
+        assert names == [self.prefix.name]
+
+    def test_search_is_case_insensitive(self):
+        assert self.search("LADDER")[0] == self.exact.name
+
+
+class SearchFacetsMatchListTestCase(TestCase):
+    """Facet counts are computed with the same matching rules as the list."""
+
+    def setUp(self):
+        self.user = ItemOwnerUserFactory(
+            username="facetsearch", email="facet@example.com", password=TEST_PASSWORD
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        Item.objects.create(
+            name="Ladder rack",
+            description="Fits on a van",
+            user=self.user,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+        Item.objects.create(
+            name="Paint bucket",
+            description="Sold with a ladder",
+            user=self.user,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="garden",
+        )
+
+    def test_multi_term_query_narrows_facet_counts(self):
+        url = reverse("api:public-item-facets") + "?search=ladder+van"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        categories = response.json()["categories"]
+        assert categories == [{"category": "tools", "count": 1}]
+
+
+class FederatedSearchRankingTestCase(TestCase):
+    """The unified local + remote search ranks by relevance, not by name.
+
+    Local and remote rows are merged in Python, so this covers the in-memory
+    ranking path; only local items are needed to pin the ordering down.
+    """
+
+    def setUp(self):
+        self.user = ItemOwnerUserFactory(
+            username="fedsearch", email="fed@example.com", password=TEST_PASSWORD
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        for name, description in [
+            ("Apron", "Protects from a ladder's rust"),
+            ("Ladder", "Reaches the roof"),
+        ]:
+            Item.objects.create(
+                name=name,
+                description=description,
+                user=self.user,
+                sales_type=SalesType.SELL,
+                status=ItemStatus.AVAILABLE,
+                visibility=VisibilityType.PUBLIC,
+                category="tools",
+            )
+
+    def test_title_match_comes_before_description_match(self):
+        url = reverse("api:federated-item-list") + "?search=ladder&scope=local"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        names = [item["name"] for item in response.json()["results"]]
+        # Alphabetically "Apron" would come first; relevance puts it last.
+        assert names == ["Ladder", "Apron"]

--- a/backend/bubble/items/tests/test_search.py
+++ b/backend/bubble/items/tests/test_search.py
@@ -7,12 +7,15 @@ from urllib.parse import quote
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory
 
 from bubble.items.api.search import (
     MAX_SEARCH_TERMS,
+    RelevanceOrderingFilter,
     is_fuzzy_matchable,
     parse_search_query,
+    ranked_search,
     relevance_score,
     strip_accents,
 )
@@ -354,3 +357,58 @@ class FuzzySearchTestCase(TestCase):
             category="tools",
         )
         assert self.search("tisch") == []
+
+
+class _OrderingView:
+    """The bits of a viewset that ``OrderingFilter`` actually reads."""
+
+    ordering = ["-created_at"]
+    ordering_fields = ["created_at", "name", "price", "relevance"]
+
+
+class RelevanceOrderingFilterTestCase(TestCase):
+    """How a requested ordering is resolved against the rank annotation."""
+
+    def setUp(self):
+        self.filter = RelevanceOrderingFilter()
+        self.view = _OrderingView()
+        self.factory = APIRequestFactory()
+
+    def resolve(self, query, *, searching=True):
+        """Return the ordering terms the filter would sort by."""
+        queryset = Item.objects.all()
+        if searching:
+            queryset = ranked_search(queryset, "ladder")
+        request = Request(self.factory.get("/", query))
+        return self.filter.get_ordering(request, queryset, self.view)
+
+    def test_no_ordering_while_searching_ranks_then_falls_back(self):
+        assert self.resolve({"search": "ladder"}) == ["-search_rank", "-created_at"]
+
+    def test_explicit_relevance_keeps_the_tie_breaker(self):
+        """Rank alone would let equally-ranked rows drift between pages."""
+        assert self.resolve({"ordering": "relevance"}) == [
+            "-search_rank",
+            "-created_at",
+        ]
+
+    def test_reversed_relevance_keeps_the_tie_breaker(self):
+        assert self.resolve({"ordering": "-relevance"}) == [
+            "search_rank",
+            "-created_at",
+        ]
+
+    def test_relevance_followed_by_a_field_is_left_alone(self):
+        """An explicit second term already settles the ties."""
+        assert self.resolve({"ordering": "relevance,name"}) == ["-search_rank", "name"]
+
+    def test_explicit_field_ordering_wins_over_relevance(self):
+        assert self.resolve({"ordering": "-price"}) == ["-price"]
+
+    def test_relevance_without_a_search_falls_back_to_the_default(self):
+        assert self.resolve({"ordering": "relevance"}, searching=False) == [
+            "-created_at"
+        ]
+
+    def test_no_ordering_without_a_search_keeps_the_default(self):
+        assert self.resolve({}, searching=False) == ["-created_at"]

--- a/backend/bubble/items/tests/test_search.py
+++ b/backend/bubble/items/tests/test_search.py
@@ -2,6 +2,8 @@
 
 # mypy: ignore-errors
 
+from urllib.parse import quote
+
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -9,8 +11,10 @@ from rest_framework.test import APIClient
 
 from bubble.items.api.search import (
     MAX_SEARCH_TERMS,
+    is_fuzzy_matchable,
     parse_search_query,
     relevance_score,
+    strip_accents,
 )
 from bubble.items.models import Item, ItemStatus, SalesType, VisibilityType
 from bubble.items.tests.factories import ItemOwnerUserFactory
@@ -215,3 +219,138 @@ class FederatedSearchRankingTestCase(TestCase):
         names = [item["name"] for item in response.json()["results"]]
         # Alphabetically "Apron" would come first; relevance puts it last.
         assert names == ["Ladder", "Apron"]
+
+
+class StripAccentsTestCase(TestCase):
+    """The Python fold used to rank federated results."""
+
+    def test_folds_combining_marks(self):
+        assert strip_accents("Fahrräder Anhänger") == "Fahrrader Anhanger"
+
+    def test_folds_letters_without_a_decomposition(self):
+        """PostgreSQL's unaccent expands these; Unicode decomposition does not."""
+        assert strip_accents("Straße") == "Strasse"
+        assert strip_accents("Œuf") == "OEuf"
+
+    def test_leaves_unaccented_text_alone(self):
+        assert strip_accents("Ladder rack 3m") == "Ladder rack 3m"
+
+
+class FuzzyMatchEligibilityTestCase(TestCase):
+    """Which terms are allowed a second, approximate pass."""
+
+    def test_long_single_words_are_eligible(self):
+        assert is_fuzzy_matchable("bohrmaschine")
+
+    def test_short_words_are_not(self):
+        assert not is_fuzzy_matchable("saw")
+        assert not is_fuzzy_matchable("bike")
+
+    def test_quoted_phrases_are_not(self):
+        assert not is_fuzzy_matchable("ladder rack")
+
+
+class AccentInsensitiveSearchTestCase(TestCase):
+    """Diacritics never decide whether an item is found."""
+
+    def setUp(self):
+        self.user = ItemOwnerUserFactory(
+            username="accentuser", email="accent@example.com", password=TEST_PASSWORD
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        def make(name, description=""):
+            return Item.objects.create(
+                name=name,
+                description=description,
+                user=self.user,
+                sales_type=SalesType.SELL,
+                status=ItemStatus.AVAILABLE,
+                visibility=VisibilityType.PUBLIC,
+                category="tools",
+            )
+
+        self.accented = make("Fahrräder Anhänger")
+        self.plain = make("Fahrraeder Zubehoer", "Passt an einen Anhanger")
+
+    def search(self, query):
+        url = reverse("api:public-item-list") + f"?search={quote(query)}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        return [item["name"] for item in response.json()["results"]]
+
+    def test_unaccented_query_finds_accented_item(self):
+        assert self.search("fahrrader")[0] == self.accented.name
+
+    def test_accented_query_finds_accented_item(self):
+        assert self.search("Fahrräder")[0] == self.accented.name
+
+    def test_ae_spelling_is_reached_through_the_fuzzy_tier(self):
+        """German transliteration ("ae" for "ä") survives, ranked second."""
+        assert self.search("fahrrader") == [self.accented.name, self.plain.name]
+
+    def test_accents_are_folded_in_the_description_too(self):
+        assert self.search("anhänger") == [self.accented.name, self.plain.name]
+
+
+class FuzzySearchTestCase(TestCase):
+    """A mistyped term still finds the item, ranked below every literal match."""
+
+    def setUp(self):
+        self.user = ItemOwnerUserFactory(
+            username="fuzzyuser", email="fuzzy@example.com", password=TEST_PASSWORD
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        def make(name, description=""):
+            return Item.objects.create(
+                name=name,
+                description=description,
+                user=self.user,
+                sales_type=SalesType.SELL,
+                status=ItemStatus.AVAILABLE,
+                visibility=VisibilityType.PUBLIC,
+                category="tools",
+            )
+
+        self.literal = make("Bohrmaschine")
+        self.in_description = make("Werkbank", "Passend für eine Bohrmaschine")
+        # Misspelled in the listing itself — only reachable approximately.
+        self.misspelled = make("Bohrmaschiene Ersatzteil", "Kleinteile")
+        self.unrelated = make("Leiter", "Aus Holz")
+
+    def search(self, query):
+        url = reverse("api:public-item-list") + f"?search={quote(query)}"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        return [item["name"] for item in response.json()["results"]]
+
+    def test_typo_in_the_listing_is_still_found(self):
+        assert self.misspelled.name in self.search("bohrmaschine")
+
+    def test_typo_in_the_query_is_still_found(self):
+        assert self.literal.name in self.search("bohrmaschiene")
+
+    def test_fuzzy_matches_rank_below_literal_ones(self):
+        assert self.search("bohrmaschine") == [
+            self.literal.name,
+            self.in_description.name,
+            self.misspelled.name,
+        ]
+
+    def test_unrelated_items_stay_out(self):
+        assert self.unrelated.name not in self.search("bohrmaschine")
+
+    def test_short_terms_are_not_matched_fuzzily(self):
+        """ "tisch" scores 0.5 against "Fisch Eimer" — below the bar, and too short."""
+        Item.objects.create(
+            name="Fisch Eimer",
+            user=self.user,
+            sales_type=SalesType.SELL,
+            status=ItemStatus.AVAILABLE,
+            visibility=VisibilityType.PUBLIC,
+            category="tools",
+        )
+        assert self.search("tisch") == []

--- a/docs/search.md
+++ b/docs/search.md
@@ -121,7 +121,10 @@ letters; the SQL path, which calls `unaccent` itself, is what decides inclusion.
 `?ordering=relevance` sorts best-match-first, and is the **default whenever a
 search term is present**. Any explicit `ordering` (`name`, `-price`,
 `-created_at`, …) still wins, and `relevance` is ignored when no search is
-active, since there is nothing to rank. The browse page adds a "Relevance" entry
+active, since there is nothing to rank. Rank on its own never ends the sort:
+whether relevance was requested or applied by default, the endpoint's own
+ordering follows it to settle ties, so equally-ranked rows cannot drift between
+pages. The browse page adds a "Relevance" entry
 to its sort menu that only appears while a term is active.
 
 ### Why substring matching, not full-text search

--- a/docs/search.md
+++ b/docs/search.md
@@ -15,17 +15,24 @@ every endpoint that accepts a `search` query parameter:
 | `api:federated-item-list` (`/api/federated-items/`) | title, description (local **and** remote items) |
 | `api:book-list` (`/api/books/`) | title, description, ISBN, author, publisher, topic |
 
+All of them fold accents on both sides of the comparison, and all of them apply
+the approximate (typo-tolerant) pass to the **title** only. The book metadata is
+matched literally: those are JSONB paths, where Django reads an `unaccent`
+transform as one more key in the document rather than as a function call.
+
 ---
 
 ## 1. What changed
 
 Previously every endpoint ran the same query: `name ILIKE %q% OR description ILIKE %q%`,
-returning matches newest-first. Two consequences:
+returning matches newest-first. Three consequences:
 
 - An item **named** "Ladder" and an item whose description happens to end with
   "…store it next to the ladder" were equally good hits, and the newer one won.
 - A two-word query was matched as one literal string, so "ladder aluminium"
   found nothing unless those words appeared adjacent, in that order.
+- A diacritic or a typo was fatal: "fahrrader" missed *Fahrräder* entirely, and
+  a listing spelled *Bohrmaschiene* was unreachable.
 
 ### Matching
 
@@ -35,8 +42,47 @@ any of the searched fields — terms are ANDed, fields are ORed. So "ladder
 aluminium" now finds *Aluminium step ladder*, and adding a word narrows results
 instead of emptying them.
 
+Every comparison folds diacritics through PostgreSQL's `unaccent`, on both the
+column and the term, so "fahrrader" finds *Fahrräder* and "Fahrräder" finds
+*Fahrrader*. A term that matches nothing literally gets a second, approximate
+pass against the **title** using `pg_trgm`'s word similarity, so
+"bohrmaschiene" still finds *Bohrmaschine*. Both extensions are installed by
+`items` migration `0020_search_extensions`; they are *trusted* on PostgreSQL 13+,
+so the database owner can create them without superuser rights.
+
 Facet counts use the exact same matcher, so the number on a facet chip always
 matches the number of results you get by clicking it.
+
+#### Calibrating the fuzzy pass
+
+`word_similarity(term, title)` scores the term against the best-matching run of
+words in the title. Measured against realistic German/English listings:
+
+| Term / title | Score |
+| --- | --- |
+| bohrmaschine / Bohrmaschiene | 0.77 |
+| kinderwagen / Kinderwagn | 0.75 |
+| gitarre / Gitare | 0.67 |
+| projektor / Projecktor | 0.62 |
+| hammer / Hammar drill | 0.57 |
+| leiter / Leitre | 0.57 |
+| **threshold** | **0.55** |
+| drucker / Druker | 0.50 |
+| tisch / Fisch Eimer | 0.50 |
+| law / Ladder | 0.50 |
+| leiter / Liter Flasche | 0.44 |
+
+`FUZZY_SIMILARITY_THRESHOLD = 0.55` sits in the gap between one-letter slips in
+words of six characters or more and the coincidental matches below. Two terms
+never get the fuzzy pass at all (`is_fuzzy_matchable`):
+
+- **Shorter than `MIN_FUZZY_TERM_LENGTH` (5).** At that length one different
+  character is usually a different word — "law" scores 0.50 against *Ladder*.
+- **Quoted phrases.** Asking for a phrase is already an instruction to take the
+  spelling literally.
+
+Only the title is matched fuzzily. A typo-tolerant description match pulls in
+far more than it rescues.
 
 ### Ranking
 
@@ -51,17 +97,24 @@ Each row is scored, and higher scores come first:
 | *per term:* term in title | 8 |
 | *per term:* term in an extra field (ISBN, author, …) | 4 |
 | *per term:* term in description | 2 |
+| *per term:* term merely *similar* to the title | 1 |
 
-The tiers are additive, so an exact title match scores 100 + 50 + 25 + 8 = 183
-while a description-only hit scores 12. Anything matching in the title outranks
-everything matching only in the description — which is the property the ranking
-exists for. Ties fall back to the endpoint's default ordering (newest first), so
-pagination stays stable.
+The tiers are additive, so an exact title match scores 100 + 50 + 25 + 8 + 1 =
+184 while a description-only hit scores 12 and a rescued typo scores 1. Anything
+matching in the title outranks everything matching only in the description —
+which is the property the ranking exists for — and an approximate match ranks
+below both, so typo tolerance extends the result list downwards instead of
+reshuffling it. Ties fall back to the endpoint's default ordering (newest
+first), so pagination stays stable.
 
 Two implementations share those weights: `relevance_annotation` builds a SQL
 expression for querysets, and `relevance_score` scores a row in Python for the
 federated endpoint, which merges local and remote rows in memory and so cannot
-sort them in the database. **They must stay in sync.**
+sort them in the database. **They must stay in sync.** The Python side has no
+fuzzy tier — that needs PostgreSQL — so a federated row rescued by a typo scores
+0 and lands at the bottom of that list, which is where its one point would have
+put it anyway. Its `strip_accents` helper mirrors `unaccent` for the European
+letters; the SQL path, which calls `unaccent` itself, is what decides inclusion.
 
 ### Ordering
 
@@ -77,8 +130,10 @@ PostgreSQL full-text search (`SearchVector`/`SearchRank`) was considered and not
 adopted *yet*. `tsvector` matching is lexeme-based: it would stop "saw" from
 finding "Chainsaw" and stop "9780441" from finding a full ISBN — both things
 people do here, on a catalogue whose titles are short, multilingual, and full of
-model numbers. Substring matching keeps those working. The cost is that ranking
-signals stay coarse and matching cannot handle typos; see below.
+model numbers. Substring matching keeps those working, and `pg_trgm` covers the
+typo tolerance that would otherwise be the main argument for switching. The cost
+is that ranking signals stay coarse: there is no term-frequency or field-length
+normalisation, only the tier table above.
 
 ---
 
@@ -86,21 +141,33 @@ signals stay coarse and matching cannot handle typos; see below.
 
 Roughly in order of value per unit of work.
 
-### 2.1 Typo tolerance with `pg_trgm` (high value)
+### 2.1 Index the search columns (small, do it when the catalogue grows)
 
-`CREATE EXTENSION pg_trgm` plus a `TrigramSimilarity` annotation would make
-"laddr" find *Ladder*, and a GIN trigram index on `items_item.name` would
-additionally make the current `ILIKE %…%` title matching index-backed rather
-than a sequential scan. Suggested shape: keep the strict match as-is, and fall
-back to `similarity(name, query) > 0.3` when it returns nothing, so fuzzy hits
-never dilute exact ones. Needs a migration with `TrigramExtension()`, so check
-that the deploy database user may create extensions.
+Every comparison wraps the column in `unaccent(…)`, so no plain index on `name`
+or `description` can serve it, and each search is a sequential scan. On a
+neighbourhood catalogue (thousands of rows) that is fine and no index was added.
+When it stops being fine, the fix is a functional GIN trigram index — which needs
+an `IMMUTABLE` wrapper, because `unaccent` itself is not:
 
-### 2.2 Accent and case folding with `unaccent` (high value, small)
+```sql
+CREATE FUNCTION immutable_unaccent(text) RETURNS text
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
+$$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;
 
-"Fahrrader" does not currently find *Fahrräder*, and for a German-language
-instance that is a common miss. `CREATE EXTENSION unaccent` plus an
-`unaccent(lower(name))` functional index fixes it for both matching and ranking.
+CREATE INDEX items_item_name_trgm
+  ON items_item USING gin (immutable_unaccent(name) gin_trgm_ops);
+```
+
+The catch: Django's `__unaccent` lookup emits `UNACCENT(…)`, not
+`immutable_unaccent(…)`, so the index is only used once a custom `Transform` is
+registered to emit the wrapper. Measure first — `EXPLAIN ANALYZE` on a real
+search — before taking that on.
+
+### 2.2 Tune the fuzzy threshold against real queries (small)
+
+`FUZZY_SIMILARITY_THRESHOLD` (0.55) and `MIN_FUZZY_TERM_LENGTH` (5) were
+calibrated against invented typos, not observed ones. Once §2.8 is in place,
+recheck them against queries that actually returned nothing.
 
 ### 2.3 A word-boundary ranking tier (small)
 
@@ -150,5 +217,5 @@ cheapest way to find out which of 2.1–2.7 actually matters here.
 
 | File | Covers |
 | --- | --- |
-| `backend/bubble/items/tests/test_search.py` | Query parsing (quoting, dedup, term cap), the Python scorer, list ranking, explicit-ordering override, facet/list agreement, federated ranking |
+| `backend/bubble/items/tests/test_search.py` | Query parsing (quoting, dedup, term cap), the Python scorer and accent fold, fuzzy eligibility, list ranking, explicit-ordering override, accent-insensitive search, typo tolerance and its ranking, facet/list agreement, federated ranking |
 | `backend/bubble/books/tests/test_search.py` | Book ranking and JSONB metadata matching (ISBN, author) |

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,154 @@
+# Item search: matching, ranking and what to do next
+
+Search is how most people get to an item, so this doc records how the current
+implementation works, why it works that way, and which improvements are worth
+picking up next.
+
+The implementation lives in `backend/bubble/items/api/search.py` and is shared by
+every endpoint that accepts a `search` query parameter:
+
+| Endpoint | Fields matched |
+| --- | --- |
+| `api:public-item-list` (`/api/public-items/`) | title, description |
+| `api:item-list` (`/api/items/`) | title, description |
+| `api:public-item-facets` (`/api/public-items/facets/`) | title, description |
+| `api:federated-item-list` (`/api/federated-items/`) | title, description (local **and** remote items) |
+| `api:book-list` (`/api/books/`) | title, description, ISBN, author, publisher, topic |
+
+---
+
+## 1. What changed
+
+Previously every endpoint ran the same query: `name ILIKE %q% OR description ILIKE %q%`,
+returning matches newest-first. Two consequences:
+
+- An item **named** "Ladder" and an item whose description happens to end with
+  "…store it next to the ladder" were equally good hits, and the newer one won.
+- A two-word query was matched as one literal string, so "ladder aluminium"
+  found nothing unless those words appeared adjacent, in that order.
+
+### Matching
+
+The query is parsed into terms; `"quoted phrases"` stay together as one term and
+at most `MAX_SEARCH_TERMS` (8) terms are used. **Every** term has to be found, in
+any of the searched fields — terms are ANDed, fields are ORed. So "ladder
+aluminium" now finds *Aluminium step ladder*, and adding a word narrows results
+instead of emptying them.
+
+Facet counts use the exact same matcher, so the number on a facet chip always
+matches the number of results you get by clicking it.
+
+### Ranking
+
+Each row is scored, and higher scores come first:
+
+| Signal | Weight |
+| --- | --- |
+| Title is exactly the query | 100 |
+| Title starts with the query | 50 |
+| Title contains the query | 25 |
+| Description contains the query | 10 |
+| *per term:* term in title | 8 |
+| *per term:* term in an extra field (ISBN, author, …) | 4 |
+| *per term:* term in description | 2 |
+
+The tiers are additive, so an exact title match scores 100 + 50 + 25 + 8 = 183
+while a description-only hit scores 12. Anything matching in the title outranks
+everything matching only in the description — which is the property the ranking
+exists for. Ties fall back to the endpoint's default ordering (newest first), so
+pagination stays stable.
+
+Two implementations share those weights: `relevance_annotation` builds a SQL
+expression for querysets, and `relevance_score` scores a row in Python for the
+federated endpoint, which merges local and remote rows in memory and so cannot
+sort them in the database. **They must stay in sync.**
+
+### Ordering
+
+`?ordering=relevance` sorts best-match-first, and is the **default whenever a
+search term is present**. Any explicit `ordering` (`name`, `-price`,
+`-created_at`, …) still wins, and `relevance` is ignored when no search is
+active, since there is nothing to rank. The browse page adds a "Relevance" entry
+to its sort menu that only appears while a term is active.
+
+### Why substring matching, not full-text search
+
+PostgreSQL full-text search (`SearchVector`/`SearchRank`) was considered and not
+adopted *yet*. `tsvector` matching is lexeme-based: it would stop "saw" from
+finding "Chainsaw" and stop "9780441" from finding a full ISBN — both things
+people do here, on a catalogue whose titles are short, multilingual, and full of
+model numbers. Substring matching keeps those working. The cost is that ranking
+signals stay coarse and matching cannot handle typos; see below.
+
+---
+
+## 2. Suggested next steps
+
+Roughly in order of value per unit of work.
+
+### 2.1 Typo tolerance with `pg_trgm` (high value)
+
+`CREATE EXTENSION pg_trgm` plus a `TrigramSimilarity` annotation would make
+"laddr" find *Ladder*, and a GIN trigram index on `items_item.name` would
+additionally make the current `ILIKE %…%` title matching index-backed rather
+than a sequential scan. Suggested shape: keep the strict match as-is, and fall
+back to `similarity(name, query) > 0.3` when it returns nothing, so fuzzy hits
+never dilute exact ones. Needs a migration with `TrigramExtension()`, so check
+that the deploy database user may create extensions.
+
+### 2.2 Accent and case folding with `unaccent` (high value, small)
+
+"Fahrrader" does not currently find *Fahrräder*, and for a German-language
+instance that is a common miss. `CREATE EXTENSION unaccent` plus an
+`unaccent(lower(name))` functional index fixes it for both matching and ranking.
+
+### 2.3 A word-boundary ranking tier (small)
+
+Right now "cat" scores *Catalogue* and *Cat carrier* identically. A
+`name__iregex=r"\y<term>\y"` tier (PostgreSQL word boundaries) between "title
+contains" and "title starts with" would separate them. Cheap to add to the
+weight table; costs one regex per row over the already-filtered set.
+
+### 2.4 Search more fields (small, needs a product call)
+
+Category, owner name and collection name are currently *facets* but not
+searchable text, so typing "tools" into the box matches only items with the word
+in their title or description, not the whole category. Adding them to the matched
+fields (at a weight between title and description) would make the box work the
+way people expect. It does widen result sets, hence the product call.
+
+### 2.5 Highlight the matched terms in results (medium)
+
+The ranking knows *why* an item matched but the UI never says so. Marking the
+matched terms in the title/description snippet — and, where the hit was
+description-only, showing that snippet instead of the first line — would make the
+ordering legible instead of mysterious.
+
+### 2.6 Recent and suggested searches (medium)
+
+The header popup already loads facets while the user types. Adding a short list
+of the viewer's recent searches (localStorage) and the top matching item titles
+as type-ahead suggestions would cut the number of dead-end queries. Worth
+watching the facets request count if this goes in.
+
+### 2.7 Empty-state recovery (small)
+
+A query with no results currently shows an empty grid. Better: drop the last
+term and re-run ("no results for *ladder aluminium 3m* — showing results for
+*ladder aluminium*"), which is a natural fit for the AND-ed term list.
+
+### 2.8 Instrument it (small, unlocks everything else)
+
+None of the above can be prioritised with evidence today, because queries are not
+logged. Recording `(query, result count, whether a result was opened)` — no user
+id needed — would show the real zero-result and no-click queries, and is the
+cheapest way to find out which of 2.1–2.7 actually matters here.
+
+---
+
+## 3. Tests
+
+| File | Covers |
+| --- | --- |
+| `backend/bubble/items/tests/test_search.py` | Query parsing (quoting, dedup, term cap), the Python scorer, list ranking, explicit-ordering override, facet/list agreement, federated ranking |
+| `backend/bubble/books/tests/test_search.py` | Book ranking and JSONB metadata matching (ISBN, author) |

--- a/frontend/src/components/browse/BrowseNav.tsx
+++ b/frontend/src/components/browse/BrowseNav.tsx
@@ -1,11 +1,11 @@
 import { Button as MantineButton, Checkbox, Menu, Radio } from '@mantine/core';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, Sparkles } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { ConditionEnum } from '@/services/django';
 
-type SortField = 'name' | 'price' | 'date';
+type SortField = 'relevance' | 'name' | 'price' | 'date';
 type SortDir = 'asc' | 'desc';
 type Scope = 'local' | 'federated' | 'all';
 
@@ -15,6 +15,8 @@ type BrowseNavProps = {
   sortField: SortField;
   sortDir: SortDir;
   onSortChange: (field: SortField, dir: SortDir) => void;
+  /** Whether a search term is active — relevance can only be sorted on then. */
+  searchActive: boolean;
   scope: Scope;
   onScopeChange: (scope: Scope) => void;
   className?: string;
@@ -28,6 +30,7 @@ export const BrowseNav = ({
   sortField,
   sortDir,
   onSortChange,
+  searchActive,
   scope,
   onScopeChange,
   className,
@@ -59,6 +62,10 @@ export const BrowseNav = ({
       : [...selectedConditions, condition];
     onSelectedConditionsChange(nextConditions);
   };
+
+  // Relevance has a single meaningful direction (best match first), so it is
+  // not a toggle like the other two.
+  const handleRelevanceSortClick = (): void => onSortChange('relevance', 'desc');
 
   const handleDateSortClick = (): void => {
     if (sortField === 'date') {
@@ -108,7 +115,9 @@ export const BrowseNav = ({
           variant="default"
           className={cn('shrink-0', className)}
           leftSection={
-            sortDir === 'asc' ? (
+            sortField === 'relevance' ? (
+              <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : sortDir === 'asc' ? (
               <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
             ) : (
               <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
@@ -117,7 +126,11 @@ export const BrowseNav = ({
           aria-label={t('index.filterAndSort')}
           title={t('index.filterAndSort')}
         >
-          {sortField === 'price' ? t('index.sortPrice') : t('index.sortDate')}
+          {sortField === 'relevance'
+            ? t('index.sortRelevance')
+            : sortField === 'price'
+              ? t('index.sortPrice')
+              : t('index.sortDate')}
         </MantineButton>
       </Menu.Target>
 
@@ -149,6 +162,19 @@ export const BrowseNav = ({
 
         {/* Sort control */}
         <Menu.Label>{t('index.sort')}</Menu.Label>
+        {searchActive && (
+          <Menu.Item
+            onClick={handleRelevanceSortClick}
+            leftSection={
+              <Sparkles
+                className={sortField === 'relevance' ? activeSortIconClass : inactiveSortIconClass}
+                aria-hidden="true"
+              />
+            }
+          >
+            {t('index.sortRelevance')}
+          </Menu.Item>
+        )}
         <Menu.Item onClick={handleDateSortClick} leftSection={dateSortIconColored}>
           {t('index.sortDate')}
         </Menu.Item>

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -139,6 +139,7 @@ const translations = {
     'index.scopeFederated': 'Federated',
     'index.scope': 'Scope',
     'index.sortDate': 'Date',
+    'index.sortRelevance': 'Relevance',
 
     // Browse Nav
     'browse.buy': 'Donate/Sell',
@@ -854,6 +855,7 @@ const translations = {
     'index.sortPrice': 'Preis',
     'index.filterAndSort': 'Filtern und sortieren',
     'index.sortDate': 'Datum',
+    'index.sortRelevance': 'Relevanz',
     'index.scope': 'Bereich',
     'index.scopeLocal': 'Lokal',
     'index.scopeAll': 'Alle',

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -33,7 +33,7 @@ type BrowseItemsPageFilters = {
   salesTypes?: SalesTypeEnum[];
 };
 
-type SortField = 'name' | 'price' | 'date';
+type SortField = 'relevance' | 'name' | 'price' | 'date';
 type SortDir = 'asc' | 'desc';
 type Scope = 'local' | 'federated' | 'all';
 
@@ -70,7 +70,7 @@ const VALID_CATEGORIES: ItemCategoryFilter[] = [
 ] satisfies (CategoryEnum | 'all')[];
 
 const VALID_CONDITIONS: ConditionEnum[] = [0, 1, 2];
-const VALID_SORT_FIELDS: SortField[] = ['name', 'price', 'date'];
+const VALID_SORT_FIELDS: SortField[] = ['relevance', 'name', 'price', 'date'];
 const VALID_SCOPES = ['local', 'federated', 'all'] as const;
 
 // ---------------------------------------------------------------------------
@@ -134,9 +134,15 @@ const Index = () => {
 
   const sortFieldParam = params.get('sortField');
   const sortDirParam = params.get('sortDir');
-  const sortField: SortField = VALID_SORT_FIELDS.includes(sortFieldParam as SortField)
+  // Searching defaults to relevance (title matches first); browsing without a
+  // term has nothing to rank, so it stays newest-first. Relevance is only
+  // offered while a term is active.
+  const defaultSortField: SortField = searchQuery ? 'relevance' : 'date';
+  const requestedSortField = VALID_SORT_FIELDS.includes(sortFieldParam as SortField)
     ? (sortFieldParam as SortField)
-    : 'date';
+    : defaultSortField;
+  const sortField: SortField =
+    requestedSortField === 'relevance' && !searchQuery ? 'date' : requestedSortField;
   const sortDir: SortDir =
     sortDirParam === 'asc' || sortDirParam === 'desc'
       ? sortDirParam
@@ -145,6 +151,8 @@ const Index = () => {
         : 'asc';
   const ordering = (() => {
     const prefix = sortDir === 'desc' ? '-' : '';
+    // `relevance` already means best-first, so it carries no direction prefix.
+    if (sortField === 'relevance') return 'relevance';
     if (sortField === 'name') return `${prefix}name`;
     if (sortField === 'price') return `${prefix}price`;
     return `${prefix}created_at`;
@@ -316,6 +324,7 @@ const Index = () => {
               sortField={sortField}
               sortDir={sortDir}
               onSortChange={handleSortChange}
+              searchActive={!!searchQuery}
               scope={scope}
               onScopeChange={handleScopeChange}
             />


### PR DESCRIPTION
Search previously ran `name ILIKE %q% OR description ILIKE %q%` and returned
matches newest-first, so an item *called* "Ladder" lost to a newer item whose
description merely mentioned one. A multi-word query was also matched as one
literal string, so adding a word usually emptied the results.

Add `bubble/items/api/search.py`, shared by every endpoint that takes a
`search` parameter:

- Matching: the query is split into terms ("quoted phrases" stay together,
  capped at 8), and every term has to be found in one of the searched fields.
- Ranking: rows are scored from an additive weight table where each title
  tier outranks every description tier, so title hits always come first.
  `relevance_annotation` scores in SQL, `relevance_score` mirrors it in Python
  for the federated list, which merges local and remote rows in memory.
- Ordering: `?ordering=relevance` sorts best-first and is the default while a
  search is active; an explicit ordering still wins, and `relevance` is
  ignored when there is nothing to rank.

Applied to the item list, the private item list, the search facets (so facet
counts and results agree), the federated list, and the books list — where the
JSONB metadata (ISBN, author, publisher, topic) is searched too, replacing the
DRF SearchFilter that was running a second, unranked pass over the same
parameter.

The browse page gains a "Relevance" sort entry, shown only while a term is
active, and uses it by default when searching.

`docs/search.md` records the weights, the reasoning for staying with substring
matching instead of PostgreSQL full-text search, and the follow-ups that
analysis surfaced (pg_trgm typo tolerance, unaccent, word-boundary tier,
match highlighting, search instrumentation).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjDriUdSYGfN4PG9YWSAyL