### PR TITLE
fix(auth): stop the SSO auto-login redirect loop

### DIFF
--- a/frontend/src/components/auth/LoginWithSocialButton.tsx
+++ b/frontend/src/components/auth/LoginWithSocialButton.tsx
@@ -1,24 +1,36 @@
-import { redirectToSocialProvider } from '@/lib/utils';
 import { Button } from '@mantine/core';
 import { useState } from 'react';
 
 interface LoginWithSocialButtonProps {
   name: string;
-  id: string;
+  /** Starts the redirect. Resolves only if the navigation did not happen. */
+  onLogin: () => Promise<void>;
+  /** Overrides the default caption, e.g. to offer a retry after a failure. */
+  label?: string;
 }
 
-export default function LoginWithSocialButton({ name, id }: LoginWithSocialButtonProps) {
+export default function LoginWithSocialButton({
+  name,
+  onLogin,
+  label,
+}: LoginWithSocialButtonProps) {
   const [loading, setLoading] = useState(false);
 
-  function handleClick() {
+  async function handleClick() {
     if (loading) return;
     setLoading(true);
-    redirectToSocialProvider(id);
+    try {
+      await onLogin();
+    } finally {
+      // Reached only when the redirect never left the page (it throws before
+      // navigating). Otherwise the page is gone and this never runs.
+      setLoading(false);
+    }
   }
 
   return (
     <Button onClick={handleClick} disabled={loading} aria-busy={loading}>
-      {loading ? `Signing in with ${name}...` : `Login with ${name}`}
+      {loading ? `Signing in with ${name}...` : (label ?? `Login with ${name}`)}
     </Button>
   );
 }

--- a/frontend/src/components/auth/LoginWithSocialButton.tsx
+++ b/frontend/src/components/auth/LoginWithSocialButton.tsx
@@ -3,7 +3,12 @@ import { useState } from 'react';
 
 interface LoginWithSocialButtonProps {
   name: string;
-  /** Starts the redirect. Resolves only if the navigation did not happen. */
+  /**
+   * Starts the redirect. Resolving means the request to leave was handed to the
+   * browser, not that the page has gone — the navigation it triggers is still
+   * in flight — so the button stays busy from there on. It rejects only when
+   * the redirect could not be started at all.
+   */
   onLogin: () => Promise<void>;
   /** Overrides the default caption, e.g. to offer a retry after a failure. */
   label?: string;
@@ -21,9 +26,11 @@ export default function LoginWithSocialButton({
     setLoading(true);
     try {
       await onLogin();
-    } finally {
-      // Reached only when the redirect never left the page (it throws before
-      // navigating). Otherwise the page is gone and this never runs.
+      // Deliberately still busy: the page is on its way out, and flipping the
+      // caption back before it unloads would only flash.
+    } catch {
+      // The redirect never started, so the button has to be usable again. The
+      // caller reports the reason.
       setLoading(false);
     }
   }

--- a/frontend/src/components/browse/ListView.tsx
+++ b/frontend/src/components/browse/ListView.tsx
@@ -78,20 +78,14 @@ export const ListView = ({ items }: ListViewProps) => {
                 </Table.Td>
                 <Table.Td>
                   {item.sales_type && (
-                    <Badge
-                      {...getSalesTypeBadgeProps(item.sales_type as SalesTypeEnum)}
-                      size="sm"
-                    >
+                    <Badge {...getSalesTypeBadgeProps(item.sales_type as SalesTypeEnum)} size="sm">
                       {t(`item.salesType.badge.${item.sales_type}`)}
                     </Badge>
                   )}
                 </Table.Td>
                 <Table.Td>
                   {typeof item.status !== 'undefined' && item.status !== null && (
-                    <Badge
-                      color={getStatusMantineColor(item.status as Status7D3Enum)}
-                      size="sm"
-                    >
+                    <Badge color={getStatusMantineColor(item.status as Status7D3Enum)} size="sm">
                       {getStatusLabel(item.status as Status7D3Enum)
                         ? t(`status.${getStatusLabel(item.status as Status7D3Enum)}`)
                         : ''}

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -123,6 +123,17 @@ const translations = {
     'auth.loginFailed': 'Login failed. Please check your credentials.',
     'auth.unexpectedError': 'An unexpected error occurred. Please try again.',
     'auth.redirectingToProvider': 'Redirecting to {{provider}}...',
+    'auth.ssoBlockedTitle': 'Sign-in did not complete',
+    'auth.ssoBlocked.error':
+      'Your identity provider sent you back without signing you in. Try again, and contact your administrator if it keeps happening.',
+    'auth.ssoBlocked.pending':
+      'Your sign-in still needs a step that cannot be completed here. Please contact your administrator.',
+    'auth.ssoBlocked.unreachable':
+      'Bubble could not reach the server, so your sign-in status is unknown. Check your connection and try again.',
+    'auth.ssoBlocked.returned':
+      'You came back from the login provider without an active session. This often means cookies are blocked for this site.',
+    'auth.ssoErrorCode': 'Error code: {{code}}',
+    'auth.retrySignIn': 'Try {{provider}} again',
 
     // Index Page
     'index.itemsFound': '{count} items found',
@@ -843,6 +854,17 @@ const translations = {
     'auth.loginFailed': 'Anmeldung fehlgeschlagen. Bitte überprüfe deine Zugangsdaten.',
     'auth.unexpectedError': 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.',
     'auth.redirectingToProvider': 'Weiterleitung zu {{provider}}...',
+    'auth.ssoBlockedTitle': 'Anmeldung nicht abgeschlossen',
+    'auth.ssoBlocked.error':
+      'Dein Anmeldedienst hat dich zurückgeschickt, ohne dich anzumelden. Versuche es erneut und wende dich an deine Administration, wenn es weiterhin passiert.',
+    'auth.ssoBlocked.pending':
+      'Deiner Anmeldung fehlt noch ein Schritt, der hier nicht abgeschlossen werden kann. Bitte wende dich an deine Administration.',
+    'auth.ssoBlocked.unreachable':
+      'Bubble konnte den Server nicht erreichen, dein Anmeldestatus ist deshalb unbekannt. Prüfe deine Verbindung und versuche es erneut.',
+    'auth.ssoBlocked.returned':
+      'Du kommst ohne aktive Sitzung vom Anmeldedienst zurück. Häufig sind Cookies für diese Seite blockiert.',
+    'auth.ssoErrorCode': 'Fehlercode: {{code}}',
+    'auth.retrySignIn': 'Erneut mit {{provider}} anmelden',
 
     // Index Page
     'index.itemsFound': '{count} Artikel gefunden',

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -30,7 +30,10 @@ export const useAppConfig = (): UseAppConfigResult => {
     // Config rarely changes — cache for 5 minutes, don't refetch on window focus
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
-    retry: false,
+    // A failure here falls back to "login required", which on an SSO-only
+    // deployment forwards the browser to the provider — too drastic a
+    // consequence for a single failed request, so give it a couple of tries.
+    retry: 2,
   });
 
   return {

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/react';
 import { revokePushOnSignOut } from '@/lib/push';
 import { clearCachedMedia } from '@/lib/serviceWorker';
-import { authAPI, Session, SessionResponse, User } from '@/services/custom/auth';
+import { clearSsoAttempt, suppressAutoSso } from '@/lib/sso';
+import { authAPI, AuthFlow, Session, SessionResponse, User } from '@/services/custom/auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react';
 
@@ -9,6 +10,15 @@ interface AuthContextType {
   user?: User;
   session: Session | null;
   loading: boolean;
+  /**
+   * The session could not be determined — the backend did not answer, or
+   * answered with an error. Distinct from `session === null`, which is a
+   * definite "not signed in": callers that act on being signed out (the login
+   * screen forwards to the SSO provider) must not act on a failed request.
+   */
+  sessionError: boolean;
+  /** Steps allauth is waiting on, e.g. a social signup that needs a form. */
+  pendingFlows: AuthFlow[];
   signOut: () => Promise<void>;
   refreshAuth: () => Promise<void>;
 }
@@ -16,6 +26,8 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType>({
   session: null,
   loading: true,
+  sessionError: false,
+  pendingFlows: [],
   signOut: async () => {},
   refreshAuth: async () => {},
 });
@@ -31,20 +43,38 @@ export const useAuth = () => {
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useQueryClient();
 
-  const { data: sessionData, isLoading } = useQuery({
+  const {
+    data: sessionData,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['session'],
     queryFn: async () => {
-      const responseData: SessionResponse = await authAPI.getSession();
-      if (responseData.meta.is_authenticated) {
+      const responseData: SessionResponse | undefined = await authAPI.getSession();
+      if (responseData?.meta.is_authenticated) {
         const { user } = responseData.data;
         Sentry.setUser({ id: user.id, username: user.username, email: user.email });
+        // The round trip through the provider worked; let the next sign-out
+        // forward straight away instead of hitting the loop guard.
+        clearSsoAttempt();
         return responseData.data;
       }
       Sentry.setUser(null);
-      return null;
+      // Not signed in, but allauth may be waiting on a step (a pending social
+      // signup, an email verification). Keep those: the login screen must not
+      // forward to the provider again over a login that is already half done.
+      return { flows: responseData?.data?.flows ?? [] } as Partial<Session> & {
+        flows: AuthFlow[];
+      };
     },
-    retry: false,
+    // A blip on the way to the session endpoint used to read as "signed out",
+    // which on an SSO-only deployment immediately forwards the browser to the
+    // provider. Retrying twice makes a transient failure heal itself instead.
+    retry: 2,
   });
+
+  const authenticated = Boolean(sessionData && 'user' in sessionData && sessionData.user);
+  const session = authenticated ? (sessionData as Session) : null;
 
   const logoutMutation = useMutation({
     mutationFn: async () => {
@@ -79,6 +109,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     // subscription left behind would keep delivering this account's notifications
     // to a browser the next person signs in on.
     await revokePushOnSignOut();
+    // The identity provider keeps its own session, so an automatic forward would
+    // sign the user right back in and make "Sign out" look broken.
+    suppressAutoSso();
     await logoutMutation.mutateAsync();
   }, [logoutMutation]);
 
@@ -88,13 +121,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const value = useMemo(
     () => ({
-      user: sessionData?.user,
-      session: sessionData ?? null,
+      user: session?.user,
+      session,
       loading: isLoading,
+      sessionError: isError,
+      pendingFlows: authenticated ? [] : ((sessionData as { flows?: AuthFlow[] })?.flows ?? []),
       signOut,
       refreshAuth,
     }),
-    [sessionData, isLoading, signOut, refreshAuth],
+    [session, sessionData, authenticated, isLoading, isError, signOut, refreshAuth],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/lib/sso.ts
+++ b/frontend/src/lib/sso.ts
@@ -90,23 +90,27 @@ export interface SsoReturn {
  * module load, before the router ever looks at the location.
  */
 function readAndStripReturnParams(): SsoReturn {
-  if (typeof window === 'undefined') return { returned: false, error: null };
+  const none: SsoReturn = { returned: false, error: null };
+  if (typeof window === 'undefined') return none;
 
   const url = new URL(window.location.href);
-  const returned = url.searchParams.has(RETURN_PARAM);
   const error = url.searchParams.get(ERROR_PARAM);
-  // An `error` that belongs to another process (e.g. connecting an account) is
-  // not this screen's business, but it still marks a completed round trip.
-  const isLoginError = error !== null && url.searchParams.get(ERROR_PROCESS_PARAM) !== 'connect';
+  // allauth always pairs `error` with `error_process`, and only the login
+  // process concerns this screen. Requiring both keeps an unrelated `?error=`
+  // on some other link — or a failed "connect an account" flow — from being
+  // read as a returning sign-in and suppressing the forward for that load.
+  const loginError =
+    error !== null && url.searchParams.get(ERROR_PROCESS_PARAM) === 'login' ? error : null;
+  const hasReturnMarker = url.searchParams.has(RETURN_PARAM);
 
-  if (!returned && error === null) return { returned: false, error: null };
+  if (!hasReturnMarker && loginError === null) return none;
 
   for (const param of [RETURN_PARAM, ERROR_PARAM, ERROR_PROCESS_PARAM]) {
     url.searchParams.delete(param);
   }
   window.history.replaceState(window.history.state, '', url.toString());
 
-  return { returned: true, error: isLoginError ? error : null };
+  return { returned: true, error: loginError };
 }
 
 const ssoReturn = readAndStripReturnParams();

--- a/frontend/src/lib/sso.ts
+++ b/frontend/src/lib/sso.ts
@@ -1,0 +1,207 @@
+/**
+ * Social (SSO) sign-in forwarding, plus the guards that keep it from looping.
+ *
+ * When the deployment has exactly one social provider and no password login,
+ * the login screen forwards to that provider automatically (see `pages/Auth`).
+ * A full page navigation leaves the provider, comes back through the allauth
+ * callback and reloads the app — so any React state guarding the forward is
+ * gone by the time the browser is back. If that round trip does not end in an
+ * authenticated session, the freshly mounted login screen forwards again, and
+ * the browser bounces between app and provider indefinitely: the "flickering"
+ * users report.
+ *
+ * A round trip can fail to authenticate for reasons the app cannot fix and the
+ * user cannot see:
+ *
+ *   - allauth reports an error by redirecting to the callback URL with
+ *     `?error=<code>&error_process=login` (signup closed, an email address that
+ *     already belongs to another account, an expired or missing OAuth state —
+ *     the state lives in the Django session for 10 minutes, so a slow login at
+ *     the provider or a browser that dropped the session cookie ends here).
+ *   - The login can also come back *without* an error and still be
+ *     unauthenticated: allauth parks it in a pending flow (a social signup that
+ *     needs a form, e.g. when the provider sends no email address, or a pending
+ *     email verification). The session endpoint then answers 401 with those
+ *     flows listed.
+ *   - The session or config request can simply fail (offline, a 5xx, a proxy
+ *     hiccup), which the app cannot tell apart from "signed out" without
+ *     looking at the error.
+ *
+ * Two independent markers therefore record that a forward has been attempted:
+ *
+ *   1. A `sso` query parameter on the callback URL. It survives storage being
+ *      unavailable and is the most reliable signal, but allauth drops it when
+ *      it cannot recover the OAuth state (it then falls back to the configured
+ *      frontend error URL, losing the callback URL entirely).
+ *   2. A short-lived `sessionStorage` timestamp, which covers exactly that case.
+ *
+ * Either marker suppresses the automatic forward, so the user gets the login
+ * screen with a real message and a button instead of an endless bounce.
+ */
+
+import { authAPI } from '@/services/custom/auth';
+import { client } from '@/services/django/client.gen';
+
+/** Set on the callback URL so a returning browser is recognisable. */
+const RETURN_PARAM = 'sso';
+/** Appended by allauth when a social login fails; see `headless/socialaccount`. */
+const ERROR_PARAM = 'error';
+const ERROR_PROCESS_PARAM = 'error_process';
+
+const ATTEMPT_KEY = 'bubble-sso-attempt';
+/**
+ * How long a recorded attempt blocks the next automatic forward. Long enough to
+ * cover a completed round trip (a redirect chain plus the reload), short enough
+ * that a user who fixes the cause — signs in at the provider, gets an account —
+ * is forwarded automatically again rather than being stuck with the button.
+ */
+const ATTEMPT_TTL_MS = 60_000;
+
+/**
+ * Why the automatic forward is currently suppressed.
+ *
+ * - `attempt`: a forward was started and has not produced a session (yet).
+ * - `signout`: the user deliberately signed out. The provider's own session
+ *   normally outlives Bubble's, so forwarding would sign them straight back in
+ *   — "Sign out" would do nothing but flash the screen. This one has no TTL:
+ *   it holds for the rest of the tab's session, while a fresh tab (or a
+ *   relaunched installed app) signs in automatically as before.
+ */
+export type SsoSuppression = 'attempt' | 'signout';
+
+interface StoredSuppression {
+  reason: SsoSuppression;
+  at: number;
+}
+
+export interface SsoReturn {
+  /** The browser came back from a provider round trip that left it signed out. */
+  returned: boolean;
+  /** allauth's error code, when it reported one (e.g. "signup_closed"). */
+  error: string | null;
+}
+
+/**
+ * Read the markers allauth put on the URL and strip them again.
+ *
+ * Stripping matters beyond tidiness: the root route treats any query string as
+ * "this is a catalogue deep link" and redirects to /browse, so leftovers would
+ * send a successfully signed-in user to the wrong start page. Read once at
+ * module load, before the router ever looks at the location.
+ */
+function readAndStripReturnParams(): SsoReturn {
+  if (typeof window === 'undefined') return { returned: false, error: null };
+
+  const url = new URL(window.location.href);
+  const returned = url.searchParams.has(RETURN_PARAM);
+  const error = url.searchParams.get(ERROR_PARAM);
+  // An `error` that belongs to another process (e.g. connecting an account) is
+  // not this screen's business, but it still marks a completed round trip.
+  const isLoginError = error !== null && url.searchParams.get(ERROR_PROCESS_PARAM) !== 'connect';
+
+  if (!returned && error === null) return { returned: false, error: null };
+
+  for (const param of [RETURN_PARAM, ERROR_PARAM, ERROR_PROCESS_PARAM]) {
+    url.searchParams.delete(param);
+  }
+  window.history.replaceState(window.history.state, '', url.toString());
+
+  return { returned: true, error: isLoginError ? error : null };
+}
+
+const ssoReturn = readAndStripReturnParams();
+
+/** What the current page load knows about a just-finished provider round trip. */
+export function getSsoReturn(): SsoReturn {
+  return ssoReturn;
+}
+
+// Storage can throw outright (Safari with site data blocked), so every access is
+// guarded and falls back to a value that at least survives within the page.
+let fallback: StoredSuppression | null = null;
+
+function write(reason: SsoSuppression): void {
+  const stored: StoredSuppression = { reason, at: Date.now() };
+  fallback = stored;
+  try {
+    window.sessionStorage.setItem(ATTEMPT_KEY, JSON.stringify(stored));
+  } catch {
+    // Ignore: the in-memory copy and the URL marker still guard the forward.
+  }
+}
+
+function read(): StoredSuppression | null {
+  try {
+    const raw = window.sessionStorage.getItem(ATTEMPT_KEY);
+    if (raw) return JSON.parse(raw) as StoredSuppression;
+  } catch {
+    // Unreadable or unparsable: fall through to the in-memory copy.
+  }
+  return fallback;
+}
+
+/** Recorded just before leaving for the provider. */
+export function recordSsoAttempt(): void {
+  write('attempt');
+}
+
+/** Recorded on sign-out, so signing out is not undone by an instant forward. */
+export function suppressAutoSso(): void {
+  write('signout');
+}
+
+/** Called once a session exists, so the next visit forwards without friction. */
+export function clearSsoAttempt(): void {
+  fallback = null;
+  try {
+    window.sessionStorage.removeItem(ATTEMPT_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+export function getSsoSuppression(): SsoSuppression | null {
+  const stored = read();
+  if (!stored) return null;
+  if (stored.reason === 'signout') return 'signout';
+  return Date.now() - stored.at < ATTEMPT_TTL_MS ? 'attempt' : null;
+}
+
+/**
+ * Submit a hidden form that triggers an allauth social provider login redirect.
+ *
+ * The endpoint is CSRF protected, so the token has to be there *before* the
+ * form is submitted — posting an empty one lands the user on a 403 page instead
+ * of at the provider. The token normally arrives with the session request the
+ * app makes at startup; this awaits it for the cases where that request never
+ * completed (offline, a cold backend, cookies just cleared).
+ */
+export async function redirectToSocialProvider(providerId: string): Promise<void> {
+  const csrfToken = await authAPI.fetchCSRFToken();
+  if (!csrfToken) {
+    throw new Error('Could not obtain a CSRF token for the provider redirect');
+  }
+
+  // Recorded before leaving: the app does not run again until it is back.
+  recordSsoAttempt();
+
+  const form = document.createElement('form');
+  form.style.display = 'none';
+  form.method = 'POST';
+  form.action = `${client.getConfig().baseUrl}/api/_allauth/browser/v1/auth/provider/redirect`;
+  const data = {
+    provider: providerId,
+    callback_url: `${window.location.origin}/?${RETURN_PARAM}=1`,
+    csrfmiddlewaretoken: csrfToken,
+    process: 'login',
+  };
+
+  Object.entries(data).forEach(([k, v]) => {
+    const input = document.createElement('input');
+    input.name = k;
+    input.value = v;
+    form.appendChild(input);
+  });
+  document.body.appendChild(form);
+  form.submit();
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { client } from '@/services/django/client.gen';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -23,27 +22,4 @@ export function getCookie(name: string): string | null {
 }
 export function getCSRFToken() {
   return getCookie('csrftoken');
-}
-
-// Submits a hidden form that triggers an allauth social provider login redirect.
-export function redirectToSocialProvider(providerId: string) {
-  const form = document.createElement('form');
-  form.style.display = 'none';
-  form.method = 'POST';
-  form.action = `${client.getConfig().baseUrl}/api/_allauth/browser/v1/auth/provider/redirect`;
-  const data = {
-    provider: providerId,
-    callback_url: `${window.location.origin}/`,
-    csrfmiddlewaretoken: getCSRFToken() || '',
-    process: 'login',
-  };
-
-  Object.entries(data).forEach(([k, v]) => {
-    const input = document.createElement('input');
-    input.name = k;
-    input.value = v as string;
-    form.appendChild(input);
-  });
-  document.body.appendChild(form);
-  form.submit();
 }

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -111,6 +111,9 @@ const Auth = () => {
       console.error('Failed to start social login:', err);
       setRedirectingTo(null);
       setSsoError('redirect_failed');
+      // Rethrown so the button drops out of its busy state; the alert above
+      // carries the explanation.
+      throw err;
     }
   }, []);
 

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -4,11 +4,11 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { useAppConfig } from '@/hooks/useAppConfig';
 import { authAPI, LoginCredentials } from '@/services/custom/auth';
-import { redirectToSocialProvider } from '@/lib/utils';
+import { getSsoReturn, getSsoSuppression, redirectToSocialProvider } from '@/lib/sso';
 import { client } from '@/services/django/client.gen';
 import { Alert, Button, Card, Divider, PasswordInput, Text, TextInput, Title } from '@mantine/core';
 import { Eye, EyeOff, Loader } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface AuthConfig {
@@ -22,6 +22,13 @@ interface AuthConfig {
   };
 }
 
+/**
+ * Reasons not to forward to the provider on our own. All but `signout` are
+ * failures that used to end in the same silent bounce between app and provider,
+ * and are reported to the user; `signout` is the user's own choice.
+ */
+type BlockedReason = 'signout' | 'error' | 'pending' | 'unreachable' | 'returned';
+
 const Auth = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -30,14 +37,47 @@ const Auth = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { t } = useLanguage();
-  const { refreshAuth } = useAuth();
+  const { refreshAuth, sessionError, pendingFlows } = useAuth();
   const { requireLogin } = useAppConfig();
 
-  // Guards the auto-redirect so it only fires once.
-  const autoRedirectedRef = useRef(false);
+  // Guards the automatic forward against firing twice within one mount. The
+  // cross-page guards live in lib/sso: this screen is remounted by the round
+  // trip itself, so a ref alone can never see the previous attempt.
+  const autoForwardedRef = useRef(false);
 
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);
+
+  // Read once: the markers are stripped from the URL as the module loads.
+  const ssoReturn = getSsoReturn();
+  const [ssoError, setSsoError] = useState<string | null>(ssoReturn.error);
+
+  // Read once at mount: the marker describes *earlier* page loads. Re-reading it
+  // per render would flip the screen back to the button the moment this screen
+  // records its own forward, while the browser is already navigating away.
+  const [suppression] = useState(getSsoSuppression);
+
+  /**
+   * Why the automatic forward is held back, or null when it may go ahead.
+   *
+   * The forward is a full page navigation, so a failed round trip comes back to
+   * a freshly mounted screen with no memory of having tried. Without these
+   * checks it forwards again immediately, and keeps doing so — the provider
+   * signs the user straight back in, allauth fails or parks the login the same
+   * way as before, and the browser bounces until the user gives up.
+   */
+  const blockedReason: BlockedReason | null =
+    suppression === 'signout'
+      ? 'signout'
+      : ssoError
+        ? 'error'
+        : pendingFlows.some(flow => flow.is_pending)
+          ? 'pending'
+          : sessionError
+            ? 'unreachable'
+            : ssoReturn.returned || suppression === 'attempt'
+              ? 'returned'
+              : null;
 
   const [loginData, setLoginData] = useState<LoginCredentials>({
     username: '',
@@ -61,21 +101,42 @@ const Auth = () => {
     initializeCSRF();
   }, []);
 
+  const startSocialLogin = useCallback(async (provider: { id: string; name: string }) => {
+    setRedirectingTo(provider.name);
+    try {
+      await redirectToSocialProvider(provider.id);
+    } catch (err) {
+      // Usually a missing CSRF token, i.e. the backend never answered. Posting
+      // the form anyway would land the user on a bare 403 page.
+      console.error('Failed to start social login:', err);
+      setRedirectingTo(null);
+      setSsoError('redirect_failed');
+    }
+  }, []);
+
   // When anonymous access is disabled and exactly one social provider is
   // configured with no username/password login, skip the login screen and
   // forward straight to the provider. Otherwise users would only ever see a
   // single "Login with X" button that does the same thing.
-  const maybeAutoRedirect = (config: AuthConfig | null) => {
-    if (!requireLogin || autoRedirectedRef.current) return;
-    const providers = config?.data?.socialaccount?.providers ?? [];
-    const loginMethods = config?.data?.account?.login_methods ?? [];
+  const providers = authConfig?.data?.socialaccount?.providers ?? [];
+  const loginMethods = authConfig?.data?.account?.login_methods ?? [];
+  const singleProvider = providers.length === 1 && loginMethods.length === 0 ? providers[0] : null;
+  const autoForwardTo =
+    requireLogin && !loadingConfig && !blockedReason && singleProvider ? singleProvider : null;
 
-    if (providers.length === 1 && loginMethods.length === 0) {
-      autoRedirectedRef.current = true;
-      setRedirectingTo(providers[0].name);
-      redirectToSocialProvider(providers[0].id);
-    }
-  };
+  useEffect(() => {
+    if (!autoForwardTo || autoForwardedRef.current) return;
+    autoForwardedRef.current = true;
+    redirectToSocialProvider(autoForwardTo.id).catch(err => {
+      console.error('Failed to start social login:', err);
+      autoForwardedRef.current = false;
+      setSsoError('redirect_failed');
+    });
+  }, [autoForwardTo]);
+
+  // A forward under way means the page is on its way out; anything else this
+  // screen could render would only flash by.
+  const forwardingTo = redirectingTo ?? autoForwardTo?.name ?? null;
 
   // Fetch auth config to determine which login methods and social providers are available
   useEffect(() => {
@@ -88,7 +149,6 @@ const Auth = () => {
         }
         const json = await res.json();
         setAuthConfig(json);
-        maybeAutoRedirect(json);
       } catch (err) {
         console.error('Failed to fetch auth config:', err);
         setAuthConfig(null);
@@ -98,8 +158,6 @@ const Auth = () => {
     };
 
     fetchConfig();
-    // requireLogin is resolved by the time this screen renders (App gates on it)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -153,11 +211,24 @@ const Auth = () => {
           </div>
 
           <div className="space-y-6 mt-6">
+            {/* Why the automatic forward was held back, so the user is not left
+                staring at a screen that silently bounced them around. */}
+            {blockedReason && blockedReason !== 'signout' && singleProvider && (
+              <Alert color="yellow" variant="light" title={t('auth.ssoBlockedTitle')}>
+                <Text size="sm">{t(`auth.ssoBlocked.${blockedReason}`)}</Text>
+                {ssoError && (
+                  <Text size="xs" c="dimmed" className="mt-1">
+                    {t('auth.ssoErrorCode', { code: ssoError })}
+                  </Text>
+                )}
+              </Alert>
+            )}
+
             {/* Social Login Button */}
             <div className="text-center">
-              {redirectingTo ? (
+              {forwardingTo ? (
                 <Text size="sm" c="dimmed">
-                  {t('auth.redirectingToProvider', { provider: redirectingTo })}
+                  {t('auth.redirectingToProvider', { provider: forwardingTo })}
                 </Text>
               ) : loadingConfig ? (
                 <Text size="sm" c="dimmed">
@@ -165,9 +236,17 @@ const Auth = () => {
                 </Text>
               ) : (
                 // render one button per provider if available
-                (authConfig?.data?.socialaccount?.providers ?? []).map(p => (
+                providers.map(p => (
                   <div key={p.id} className="mb-2">
-                    <LoginWithSocialButton name={p.name} id={p.id} />
+                    <LoginWithSocialButton
+                      name={p.name}
+                      label={
+                        blockedReason && blockedReason !== 'signout'
+                          ? t('auth.retrySignIn', { provider: p.name })
+                          : undefined
+                      }
+                      onLogin={() => startSocialLogin(p)}
+                    />
                   </div>
                 ))
               )}
@@ -186,7 +265,7 @@ const Auth = () => {
               )}
 
               {/* show username/password login only when backend indicates methods are available */}
-              {!loadingConfig && (authConfig?.data?.account?.login_methods ?? []).length > 0 && (
+              {!loadingConfig && loginMethods.length > 0 && (
                 <>
                   <TextInput
                     label={t('auth.usernameOrEmail')}

--- a/frontend/src/services/custom/auth.ts
+++ b/frontend/src/services/custom/auth.ts
@@ -56,15 +56,32 @@ export interface LoginResponse {
   };
 }
 
+/** A step allauth is waiting on, e.g. `provider_signup` or `verify_email`. */
+export interface AuthFlow {
+  id: string;
+  is_pending?: boolean;
+}
+
 export interface SessionResponse {
   meta: {
     is_authenticated: boolean;
   };
-  data: Session;
+  /** Carries the user when authenticated, the open flows when not. */
+  data: Session & { flows?: AuthFlow[] };
 }
 
 class AuthAPI {
-  private async request<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  /**
+   * @param acceptStatuses Error statuses whose JSON body is a valid answer
+   *   rather than a failure. allauth replies 401 with the session state (and,
+   *   during a half-finished login, the pending flows) — information the caller
+   *   needs, and which must not be confused with the backend being unreachable.
+   */
+  private async request<T>(
+    endpoint: string,
+    options?: RequestInit,
+    acceptStatuses: number[] = [],
+  ): Promise<T> {
     const baseURL = client.getConfig().baseUrl;
 
     const headers: HeadersInit = {
@@ -87,6 +104,9 @@ class AuthAPI {
     });
 
     if (!response.ok) {
+      if (acceptStatuses.includes(response.status)) {
+        return (await response.json().catch(() => undefined)) as T;
+      }
       if (response.status === 401) {
         console.debug('[API] 401 Unauthorized – ignoring silently');
         return Promise.resolve(undefined as T);
@@ -123,10 +143,12 @@ class AuthAPI {
       let token = this.getCSRFToken();
       if (!token) {
         // Fetch CSRF token from Django by calling session endpoint
-        await this.request('/api/_allauth/browser/v1/auth/session', {
-          method: 'GET',
-          credentials: 'include',
-        });
+        await this.request(
+          '/api/_allauth/browser/v1/auth/session',
+          { method: 'GET', credentials: 'include' },
+          // Anonymous is the normal case here — the cookie comes with the 401.
+          [401, 410],
+        );
         token = this.getCSRFToken();
       }
       return token;
@@ -151,13 +173,21 @@ class AuthAPI {
     }
   }
 
-  // Get current session
-  async getSession(): Promise<SessionResponse> {
-    try {
-      return await this.request<SessionResponse>('/api/_allauth/browser/v1/auth/session');
-    } catch (error) {
-      throw error;
-    }
+  /**
+   * Get the current session.
+   *
+   * allauth answers 401 for an anonymous *and* for a half-finished session (a
+   * social login parked in a pending signup or email verification), with the
+   * flows in the body. Both are valid answers, so they are returned rather than
+   * thrown; only a network failure or a server error rejects, which is what
+   * lets the caller tell "signed out" apart from "backend did not answer".
+   */
+  async getSession(): Promise<SessionResponse | undefined> {
+    return await this.request<SessionResponse | undefined>(
+      '/api/_allauth/browser/v1/auth/session',
+      undefined,
+      [401, 410],
+    );
   }
 
   // Logout current user


### PR DESCRIPTION
## Summary

This PR fixes the "flickering" issue where users get stuck in an infinite redirect loop between the app and their identity provider during SSO login. The problem occurred when a social login round trip failed to authenticate but the app had no way to remember the failed attempt, causing it to immediately forward again on the next page load.

## Key Changes

- **New SSO state management module** (`lib/sso.ts`): Implements dual-marker tracking system to prevent redirect loops:
  - URL query parameter (`?sso=1`) survives across page navigations
  - `sessionStorage` timestamp provides fallback when allauth loses the OAuth state
  - Distinguishes between failed attempts (60s TTL) and deliberate sign-outs (persistent)
  - Reads and strips SSO markers from URL at module load to prevent routing issues

- **Enhanced Auth page** (`pages/Auth.tsx`):
  - Detects why automatic forwarding is blocked (error, pending flow, unreachable backend, or returned from provider)
  - Shows user-friendly alert explaining what went wrong instead of silent bouncing
  - Displays error codes from the identity provider for debugging
  - Offers explicit "Try again" button when auto-forward is suppressed
  - Uses `useCallback` and `useRef` to prevent double-forwards within a single mount

- **Improved session handling** (`hooks/useAuth.tsx`):
  - Distinguishes between "not authenticated" (definite) and "backend unreachable" (uncertain)
  - Retries session requests twice to handle transient failures
  - Tracks pending flows (e.g., incomplete social signups) returned by allauth
  - Clears SSO attempt marker on successful authentication
  - Records sign-out suppression to prevent immediate re-authentication

- **Updated auth API** (`services/custom/auth.ts`):
  - Accepts 401/410 responses as valid answers (not errors) since allauth uses them for anonymous and pending states
  - Exposes pending flows from session response for UI to check
  - Adds CSRF token fetching with proper error handling before redirect

- **Refactored social login button** (`components/auth/LoginWithSocialButton.tsx`):
  - Accepts callback instead of provider ID for better control
  - Supports custom label for retry scenarios
  - Properly handles async redirect failures

- **Localization**: Added German and English translations for all SSO error states and retry messaging

## Notable Implementation Details

- SSO markers are read once at module load (before routing) to prevent routing from interfering with cleanup
- The `blockedReason` state machine clearly documents all cases where auto-forward is suppressed
- Storage access is guarded with try-catch and falls back to in-memory state for Safari's site data blocking
- The 60-second TTL for attempt tracking balances between preventing loops and allowing users to retry after fixing the underlying issue
- Pending flows are preserved across page loads to prevent re-attempting a login that's already in progress

https://claude.ai/code/session_011hX5eucNiCgCYJE6ZVVQ4Q