### PR TITLE
fix(bookings): return 400 instead of 500 when confirming overlapping booking

### DIFF
--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -25,6 +25,27 @@ from bubble.core.api.pagination import SelectablePageSizePagination
 from bubble.items.models import ItemStatus, SalesType
 
 
+def _overlapping_booking_error(exc: IntegrityError) -> ValidationError | None:
+    """Build a friendly error when the overlap exclusion constraint fires.
+
+    Returns None when the IntegrityError is unrelated to overlapping bookings so
+    callers can re-raise the original exception.
+    """
+    if "exclude_overlapping_confirmed_bookings" not in str(exc):
+        return None
+    return ValidationError(
+        {
+            "non_field_errors": [
+                _(
+                    "This item is already rented out or has an open"
+                    " rental for the requested period."
+                    " Please choose a different time."
+                )
+            ]
+        }
+    )
+
+
 class PublicBookingViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Public read-only ViewSet for confirmed bookings.
@@ -119,19 +140,9 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
             try:
                 booking.save(update_fields=["status"])
             except IntegrityError as exc:
-                exc_str = str(exc)
-                if "exclude_overlapping_confirmed_bookings" in exc_str:
-                    raise ValidationError(
-                        {
-                            "non_field_errors": [
-                                _(
-                                    "This item is already rented out or has an open"
-                                    " rental for the requested period."
-                                    " Please choose a different time."
-                                )
-                            ]
-                        }
-                    ) from exc
+                error = _overlapping_booking_error(exc)
+                if error is not None:
+                    raise error from exc
                 raise
 
         message = _("Booking request created for {offer}").format(offer=booking.offer)
@@ -140,7 +151,13 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
         )
 
     def perform_update(self, serializer):
-        super().perform_update(serializer)
+        try:
+            super().perform_update(serializer)
+        except IntegrityError as exc:
+            error = _overlapping_booking_error(exc)
+            if error is not None:
+                raise error from exc
+            raise
 
         booking = serializer.instance
 

--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -31,7 +31,17 @@ def _overlapping_booking_error(exc: IntegrityError) -> ValidationError | None:
     Returns None when the IntegrityError is unrelated to overlapping bookings so
     callers can re-raise the original exception.
     """
-    if "exclude_overlapping_confirmed_bookings" not in str(exc):
+    # Prefer the structured constraint name from the underlying driver error;
+    # fall back to the message text when diagnostics are unavailable.
+    diag = getattr(exc.__cause__, "diag", None)
+    constraint_name = getattr(diag, "constraint_name", None) if diag else None
+    if constraint_name is not None:
+        is_overlap = constraint_name.startswith(
+            "exclude_overlapping_confirmed_bookings"
+        )
+    else:
+        is_overlap = "exclude_overlapping_confirmed_bookings" in str(exc)
+    if not is_overlap:
         return None
     return ValidationError(
         {

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1836,6 +1836,43 @@ class BookingFulfillmentTestCase(APITestCase):
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CONFIRMED
 
+    def test_owner_cannot_confirm_overlapping_booking(self):
+        """Confirming a booking that overlaps an existing confirmed one returns
+        a friendly 400 instead of an unhandled IntegrityError (500)."""
+        item = ItemFactory(
+            user=self.item_owner,
+            sales_type=SalesType.RENT,
+            price="10.00",
+            status=ItemStatus.RESERVED,
+        )
+        now = timezone.now()
+        BookingFactory(
+            user=self.booking_user,
+            item=item,
+            status=BookingStatus.CONFIRMED,
+            time_from=now,
+            time_to=now + timedelta(hours=2),
+        )
+        pending = BookingFactory(
+            user=self.booking_user,
+            item=item,
+            status=BookingStatus.PENDING,
+            time_from=now + timedelta(hours=1),
+            time_to=now + timedelta(hours=3),
+        )
+
+        self.client.force_authenticate(user=self.item_owner)
+        response = self.client.patch(
+            f"/api/bookings/{pending.id}/",
+            {"status": BookingStatus.CONFIRMED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        pending.refresh_from_db()
+        assert pending.status == BookingStatus.PENDING
+        assert not Message.objects.filter(booking=pending).exists()
+
 
 class BookingPastCancelValidationTestCase(APITestCase):
     """A booking whose rental period has already ended can no longer be

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -1869,6 +1869,8 @@ class BookingFulfillmentTestCase(APITestCase):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "non_field_errors" in response.data
+        assert "already rented out" in response.data["non_field_errors"][0]
         pending.refresh_from_db()
         assert pending.status == BookingStatus.PENDING
         assert not Message.objects.filter(booking=pending).exists()

--- a/frontend/src/components/browse/ListView.tsx
+++ b/frontend/src/components/browse/ListView.tsx
@@ -78,20 +78,14 @@ export const ListView = ({ items }: ListViewProps) => {
                 </Table.Td>
                 <Table.Td>
                   {item.sales_type && (
-                    <Badge
-                      {...getSalesTypeBadgeProps(item.sales_type as SalesTypeEnum)}
-                      size="sm"
-                    >
+                    <Badge {...getSalesTypeBadgeProps(item.sales_type as SalesTypeEnum)} size="sm">
                       {t(`item.salesType.badge.${item.sales_type}`)}
                     </Badge>
                   )}
                 </Table.Td>
                 <Table.Td>
                   {typeof item.status !== 'undefined' && item.status !== null && (
-                    <Badge
-                      color={getStatusMantineColor(item.status as Status7D3Enum)}
-                      size="sm"
-                    >
+                    <Badge color={getStatusMantineColor(item.status as Status7D3Enum)} size="sm">
                       {getStatusLabel(item.status as Status7D3Enum)
                         ? t(`status.${getStatusLabel(item.status as Status7D3Enum)}`)
                         : ''}


### PR DESCRIPTION
## Problem

Sentry issue [BUBBLE-BACKEND-1R](https://treibhaus.sentry.io/issues/134275267/) — `IntegrityError: conflicting key value violates exclusion constraint "exclude_overlapping_confirmed_bookings_with_time_to"` raised in `bubble/bookings/api/views.py:perform_update`, causing an unhandled 500 on `PATCH /api/bookings/{id}/` when confirming a booking that overlaps an existing confirmed/in-progress booking.

`perform_create` already catches this `IntegrityError` and returns a friendly 400, but `perform_update` did not.

## Fix

- Extract a shared helper `_overlapping_booking_error()` that maps the exclusion-constraint `IntegrityError` to the existing user-facing `ValidationError` message.
- Use it in both `perform_create` (unchanged behavior) and `perform_update` (new behavior), so confirming an overlapping booking returns a 400 with a clear message instead of a 500.

## Tests

- `test_owner_cannot_confirm_overlapping_booking`: owner PATCHes a pending booking to CONFIRMED while another confirmed booking overlaps → expects 400, booking stays PENDING, no message created.

Full backend suite: 496 passed, 4 pre-existing failures (books/items, confirmed present on `main`).