### PR TITLE
fix(bookings): auto-confirm self-service bookings when no rental price can be calculated

### DIFF
--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -139,13 +139,13 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
         booking = serializer.instance
 
         rental_price = booking.rental_price
-        self_service_at_listed_price = (
+        self_service_auto_confirm = (
             item
             and item.rental_self_service
             and (rental_price is None or (offer is not None and offer >= rental_price))
         )
 
-        if is_owner or self_service_at_listed_price:
+        if is_owner or self_service_auto_confirm:
             booking.status = BookingStatus.CONFIRMED
             try:
                 booking.save(update_fields=["status"])

--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -119,11 +119,14 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
 
     def perform_create(self, serializer):
         """
-        Create a booking and auto-confirm if the item has rental_self_service enabled
-        and the offered price matches the item's listed price exactly.
+        Create a booking and auto-confirm if the item has rental_self_service enabled.
 
-        If the offer deviates from the item price the booking stays PENDING so the
-        owner can review the custom offer, even on self-service items.
+        Auto-confirmation happens when a rental price can be calculated and the
+        offered amount is at least that price (larger offers are accepted too), or
+        when no rental price can be calculated — e.g. open-ended rentals, borrows
+        or sales — regardless of whether an offer was given. Offers below the
+        calculated rental price stay PENDING so the owner can review the custom
+        offer, even on self-service items.
         """
         item = serializer.validated_data.get("item")
         offer = serializer.validated_data.get("offer")
@@ -139,10 +142,7 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
         self_service_at_listed_price = (
             item
             and item.rental_self_service
-            and (
-                (rental_price and offer and offer >= rental_price)
-                or (not rental_price and not offer)
-            )
+            and (rental_price is None or (offer is not None and offer >= rental_price))
         )
 
         if is_owner or self_service_at_listed_price:

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -829,8 +829,10 @@ class BookingItemStatusSignalTestCase(APITestCase):
 
 
 class BookingAutoConfirmPriceCheckTestCase(APITestCase):
-    """Auto-approval on self-service items must only trigger when the offered
-    price exactly matches the calculated rental_price (item.price * hours)."""
+    """Auto-approval on self-service items triggers when the offered price is at
+    least the calculated rental_price (item.price * hours) — equal and higher
+    offers auto-confirm. When no rental_price can be calculated (open-ended
+    rentals, borrows, sales) any offered amount is auto-confirmed too."""
 
     def setUp(self):
         self.client = APIClient()
@@ -884,10 +886,11 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
         booking = Booking.objects.get(id=response.data["id"])
         assert booking.status == BookingStatus.PENDING
 
-    def test_higher_offer_stays_pending(self):
+    def test_higher_offer_auto_confirms(self):
         """
-        Booking with offer > rental_price stays PENDING
-        even on a self-service item.
+        A self-service booking is auto-confirmed even when the offer exceeds
+        the calculated rental_price. The owner's requested amount acts as a
+        floor, not a cap, so paying more never needs manual review.
         """
         self.client.force_authenticate(user=self.booking_user)
 
@@ -899,6 +902,60 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["status"] == BookingStatus.CONFIRMED
+        booking = Booking.objects.get(id=response.data["id"])
+        assert booking.status == BookingStatus.CONFIRMED
+        assert str(booking.offer.amount) == "999.99"
+
+    def test_open_end_rental_with_offer_auto_confirms(self):
+        """
+        An open-ended self-service rental has no time_to, so rental_price is
+        None. An offered amount is still auto-accepted instead of waiting for
+        owner review.
+        """
+        open_end_item = SelfServiceItemFactory(
+            user=self.item_owner,
+            sales_type=SalesType.RENT,
+            price="10.00",
+            rental_open_end=True,
+        )
+        self.client.force_authenticate(user=self.booking_user)
+
+        response = self.client.post(
+            "/api/bookings/",
+            {"item": str(open_end_item.id), "offer": "15.00"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == BookingStatus.CONFIRMED
+        booking = Booking.objects.get(id=response.data["id"])
+        assert booking.status == BookingStatus.CONFIRMED
+        assert str(booking.offer.amount) == "15.00"
+
+    def test_borrow_self_service_with_offer_auto_confirms(self):
+        """
+        A self-service borrow item has no price, so rental_price is None. An
+        offered amount (e.g. a donation) is still auto-accepted.
+        """
+        borrow_item = SelfServiceItemFactory(
+            user=self.item_owner,
+            sales_type=SalesType.BORROW,
+            price=None,
+            rental_open_end=True,
+        )
+        self.client.force_authenticate(user=self.booking_user)
+
+        response = self.client.post(
+            "/api/bookings/",
+            {"item": str(borrow_item.id), "offer": "5.00"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == BookingStatus.CONFIRMED
+        booking = Booking.objects.get(id=response.data["id"])
+        assert booking.status == BookingStatus.CONFIRMED
+        assert str(booking.offer.amount) == "5.00"
 
     def test_non_self_service_exact_price_stays_pending(self):
         """


### PR DESCRIPTION
## Problem

On self-service items (`rental_self_service`), auto-confirmation only triggered when the booking had a calculable `rental_price` **and** an offer >= that price, **or** when `rental_price` was `None` and no offer was given. When `rental_price` was `None` (open-ended rentals without `time_to`, borrows, or sales) and an offer **was** given, the booking stayed PENDING and required manual owner review — even though the item is set to auto-accept.

## Fix

In `perform_create` (`backend/bubble/bookings/api/views.py`), a self-service booking is now auto-confirmed whenever:

- `rental_price` can be calculated and the offer is at least that price (larger offers included), **or**
- `rental_price` is `None` — regardless of whether an offer was submitted.

Offers below a calculable `rental_price` still stay PENDING for owner review. Also corrected the outdated docstring and misleading test name/docstring that claimed only *exact* price matches auto-confirm.

## Tests

- Renamed `test_higher_offer_stays_pending` → `test_higher_offer_auto_confirms` (asserts CONFIRMED + offer preserved).
- Added `test_open_end_rental_with_offer_auto_confirms`: open-ended self-service rental, offer given, `rental_price is None` → CONFIRMED.
- Added `test_borrow_self_service_with_offer_auto_confirms`: no-price borrow, offer given → CONFIRMED.

Backend suite: 498 passed; the 4 failures (books/items/locations) are pre-existing on `main`.