### PR TITLE
fix(bookings): don't auto-confirm open-ended self-service bookings

### DIFF
--- a/backend/bubble/bookings/api/views.py
+++ b/backend/bubble/bookings/api/views.py
@@ -123,10 +123,16 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
 
         Auto-confirmation happens when a rental price can be calculated and the
         offered amount is at least that price (larger offers are accepted too), or
-        when no rental price can be calculated — e.g. open-ended rentals, borrows
-        or sales — regardless of whether an offer was given. Offers below the
-        calculated rental price stay PENDING so the owner can review the custom
-        offer, even on self-service items.
+        when no rental price can be calculated — e.g. borrows or sales — regardless
+        of whether an offer was given. Offers below the calculated rental price
+        stay PENDING so the owner can review the custom offer, even on self-service
+        items.
+
+        Open-ended bookings (no return date, ``time_to`` is None) are never
+        auto-confirmed: they represent an indefinite hold on the item, and the
+        open-end exclusion constraint allows only one such booking per item, so
+        auto-confirming one would permanently block the item from being booked
+        again. They stay PENDING for owner review.
         """
         item = serializer.validated_data.get("item")
         offer = serializer.validated_data.get("offer")
@@ -142,6 +148,7 @@ class BookingViewSet(viewsets.ModelViewSet, PublicBookingViewSet):
         self_service_auto_confirm = (
             item
             and item.rental_self_service
+            and booking.time_to is not None
             and (rental_price is None or (offer is not None and offer >= rental_price))
         )
 

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -172,7 +172,8 @@ class BookingAutoConfirmTestCase(APITestCase):
         """
         A self-service item with no price (e.g. borrow) has rental_price == None.
         When no offer is submitted the booking should auto-confirm because
-        offer (None) == rental_price (None).
+        offer (None) == rental_price (None). A definite return date is provided
+        so the booking is not open-ended.
         """
         borrow_item = SelfServiceItemFactory(
             user=self.item_owner,
@@ -184,7 +185,11 @@ class BookingAutoConfirmTestCase(APITestCase):
 
         response = self.client.post(
             "/api/bookings/",
-            {"item": str(borrow_item.id)},
+            {
+                "item": str(borrow_item.id),
+                "time_from": timezone.now(),
+                "time_to": timezone.now() + timedelta(days=1),
+            },
             format="json",
         )
 
@@ -906,11 +911,12 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
         assert booking.status == BookingStatus.CONFIRMED
         assert str(booking.offer.amount) == "999.99"
 
-    def test_open_end_rental_with_offer_auto_confirms(self):
+    def test_open_end_rental_with_offer_stays_pending(self):
         """
-        An open-ended self-service rental has no time_to, so rental_price is
-        None. An offered amount is still auto-accepted instead of waiting for
-        owner review.
+        An open-ended self-service rental has no time_to. Because it is an
+        indefinite hold (the open-end exclusion constraint allows only one such
+        booking per item and would permanently block re-booking), it is never
+        auto-confirmed — the offered amount waits for owner review.
         """
         open_end_item = SelfServiceItemFactory(
             user=self.item_owner,
@@ -927,15 +933,16 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["status"] == BookingStatus.CONFIRMED
+        assert response.data["status"] == BookingStatus.PENDING
         booking = Booking.objects.get(id=response.data["id"])
-        assert booking.status == BookingStatus.CONFIRMED
+        assert booking.status == BookingStatus.PENDING
         assert str(booking.offer.amount) == "15.00"
 
-    def test_borrow_self_service_with_offer_auto_confirms(self):
+    def test_borrow_self_service_with_offer_stays_pending(self):
         """
         A self-service borrow item has no price, so rental_price is None. An
-        offered amount (e.g. a donation) is still auto-accepted.
+        open-ended borrow (no time_to) is an indefinite hold and stays PENDING
+        for owner review rather than auto-confirming.
         """
         borrow_item = SelfServiceItemFactory(
             user=self.item_owner,
@@ -952,9 +959,9 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["status"] == BookingStatus.CONFIRMED
+        assert response.data["status"] == BookingStatus.PENDING
         booking = Booking.objects.get(id=response.data["id"])
-        assert booking.status == BookingStatus.CONFIRMED
+        assert booking.status == BookingStatus.PENDING
         assert str(booking.offer.amount) == "5.00"
 
     def test_non_self_service_exact_price_stays_pending(self):
@@ -989,6 +996,74 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["status"] == BookingStatus.CONFIRMED
+
+    def test_rented_out_item_can_still_be_booked_for_future_slot(self):
+        """
+        An item that is currently rented out (active confirmed booking, item
+        status RENTED) can still be booked for a future slot that has no
+        confirmed booking for that time range.
+        """
+        now = timezone.now()
+        active = SelfServiceItemFactory(user=self.item_owner, price=None)
+        self.client.force_authenticate(user=self.booking_user)
+        active_booking = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(active.id),
+                "time_from": now - timedelta(days=1),
+                "time_to": now + timedelta(days=1),
+            },
+            format="json",
+        )
+        assert active_booking.status_code == status.HTTP_201_CREATED, (
+            active_booking.content
+        )
+        assert active_booking.data["status"] == BookingStatus.CONFIRMED
+        active.refresh_from_db()
+        assert active.status == ItemStatus.RENTED
+
+        other_user = UserFactory()
+        other_user.groups.add(self.default_group)
+        self.client.force_authenticate(user=other_user)
+        future = now + timedelta(days=30)
+        response = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(active.id),
+                "time_from": future,
+                "time_to": future + timedelta(days=2),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        assert response.data["status"] == BookingStatus.CONFIRMED
+
+    def test_open_end_no_price_booking_stays_pending_and_does_not_block(self):
+        """
+        A self-service booking without a return date (open-ended) is not
+        auto-confirmed, so the item is not permanently blocked: a second
+        open-ended booking by another user is accepted without the overlap
+        error.
+        """
+        open_end_item = SelfServiceItemFactory(
+            user=self.item_owner, price=None, rental_open_end=True
+        )
+        self.client.force_authenticate(user=self.booking_user)
+        first = self.client.post(
+            "/api/bookings/", {"item": str(open_end_item.id)}, format="json"
+        )
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+        assert first.data["status"] == BookingStatus.PENDING
+
+        other_user = UserFactory()
+        other_user.groups.add(self.default_group)
+        self.client.force_authenticate(user=other_user)
+        second = self.client.post(
+            "/api/bookings/", {"item": str(open_end_item.id)}, format="json"
+        )
+        assert second.status_code == status.HTTP_201_CREATED, second.content
+        assert second.data["status"] == BookingStatus.PENDING
 
 
 class BookingOpenEndRentalTestCase(APITestCase):


### PR DESCRIPTION
## What

Fixes the **"This item is already rented out or has an open rental for the requested period"** error that appeared when booking a rentable item with no rental amount set.

## Root cause

Booking a self-service item **without a return date** (`time_to` = None, i.e. an open-ended booking) was auto-confirmed into an indefinite hold. The `exclude_overlapping_confirmed_bookings_without_time_to` exclusion constraint allows only **one** open-ended confirmed booking per item — so the first auto-confirmed open-ended booking permanently blocked the item, and every subsequent booking attempt failed with the overlap error.

## Changes

- **`backend/bubble/bookings/api/views.py`** — open-ended self-service bookings (no `time_to`) are no longer auto-confirmed; they stay **PENDING** for owner review. Auto-confirm still applies to bookings with a definite return date (including no-price borrows/sales).
- **`backend/bubble/bookings/tests/tests.py`** — updated the two open-ended auto-confirm tests to expect PENDING, and added:
  - `test_rented_out_item_can_still_be_booked_for_future_slot` — an item currently RENTED can still be booked for a future slot with no confirmed booking.
  - `test_open_end_no_price_booking_stays_pending_and_does_not_block` — a no-price open-ended booking no longer permanently blocks the item.

## Note

A previous version of this PR disabled the booking button for RENTED items. That was wrong: a rented-out item must remain bookable for future free slots, and the backend already permits non-overlapping future bookings. That approach was reverted in favor of this root-cause fix.

## Verification

- Backend: full suite passes (504 tests), bookings suite (92 tests).
- `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)