### PR TITLE
feat(bookings): add BookingAdmin overview with confirmed price and filters

### DIFF
--- a/backend/bubble/bookings/admin.py
+++ b/backend/bubble/bookings/admin.py
@@ -1,5 +1,40 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
+from simple_history.admin import SimpleHistoryAdmin
 
 from .models import Booking
 
-admin.site.register(Booking)
+
+@admin.register(Booking)
+class BookingAdmin(SimpleHistoryAdmin):
+    list_display = (
+        "item",
+        "user",
+        "status",
+        "time_from",
+        "time_to",
+        "confirmed_price",
+        "created_at",
+    )
+    list_filter = (
+        "status",
+        ("item", admin.RelatedOnlyFieldListFilter),
+        ("user", admin.RelatedOnlyFieldListFilter),
+    )
+    search_fields = ("item__name", "user__username", "user__name")
+    ordering = ("-created_at",)
+    list_select_related = ("item", "user")
+    autocomplete_fields = ("item", "user")
+    readonly_fields = ("created_at", "updated_at", "ap_id")
+
+    @admin.display(description=_("Confirmed price"))
+    def confirmed_price(self, obj):
+        """The effective price agreed for this booking.
+
+        Prefers an agreed counter-offer, then the booker's offer, then the
+        computed rental total, falling back to the item's listed price.
+        """
+        price = obj.counter_offer or obj.offer or obj.rental_price or obj.item.price
+        if price is None:
+            return None
+        return f"{price.amount} {price.currency}"

--- a/backend/bubble/bookings/admin.py
+++ b/backend/bubble/bookings/admin.py
@@ -32,9 +32,17 @@ class BookingAdmin(SimpleHistoryAdmin):
         """The effective price agreed for this booking.
 
         Prefers an agreed counter-offer, then the booker's offer, then the
-        computed rental total, falling back to the item's listed price.
+        computed rental total, falling back to the item's listed price. Uses
+        explicit None checks so a zero-valued offer is honoured.
         """
-        price = obj.counter_offer or obj.offer or obj.rental_price or obj.item.price
+        if obj.counter_offer is not None:
+            price = obj.counter_offer
+        elif obj.offer is not None:
+            price = obj.offer
+        elif obj.rental_price is not None:
+            price = obj.rental_price
+        else:
+            price = obj.item.price
         if price is None:
             return None
         return f"{price.amount} {price.currency}"


### PR DESCRIPTION
## What

Replaces the default `Booking` registration with a `BookingAdmin` so the bookings overview in the Django admin shows the useful details at a glance.

## Changes

- **`backend/bubble/bookings/admin.py`** — new `BookingAdmin` (extends `SimpleHistoryAdmin`, matching the project's `ItemAdmin`):
  - `list_display` shows the item, user, status, **booking start** (`time_from`), **booking end** (`time_to`), **confirmed price** and creation date.
  - `confirmed_price` returns the effective/agreed price: counter-offer → offer → computed rental total → item price.
  - `list_filter` for **item** and **user** (`RelatedOnlyFieldListFilter`), plus status; search by item name / username / display name.
  - `autocomplete_fields` for item and user on the change form, with `list_select_related` to avoid N+1 queries.

## Verification

- `python manage.py check` passes; `/admin/bookings/booking/` renders (HTTP 200).
- `confirmed_price` verified for offer, counter-offer and computed rental fallback.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)