### PR TITLE
fix(bookings): require a start time and surface open-ended rentals

### DIFF
--- a/backend/bubble/bookings/api/serializers.py
+++ b/backend/bubble/bookings/api/serializers.py
@@ -128,6 +128,19 @@ class BookingSerializer(serializers.ModelSerializer):
 
         return super().validate(attrs)
 
+    def validate_time_from(self, value):
+        """Require a start time when one is explicitly submitted.
+
+        A booking without ``time_from`` cannot be placed on any calendar and —
+        worse — turns into an unbounded ``tstzrange(NULL, time_to)`` in the
+        overlap exclusion constraint, blocking every other booking up to
+        ``time_to``. Omitting the field entirely is still allowed and falls
+        back to the model default ("now").
+        """
+        if value is None:
+            raise serializers.ValidationError(_("A booking requires a start time."))
+        return value
+
     def validate_status(self, value):
         """Ensure that status is a valid BookingStatus.
 

--- a/backend/bubble/bookings/models.py
+++ b/backend/bubble/bookings/models.py
@@ -162,6 +162,11 @@ class Booking(models.Model):
     @property
     def is_active(self):
         """Check if the booking is currently active."""
+        if self.time_from is None:
+            # A booking without a start time is malformed (legacy/federated
+            # rows); it can never be "currently active" — and comparing it to
+            # now would raise a TypeError, so guard instead of comparing.
+            return False
         now = timezone.now()
         return self.status == BookingStatus.CONFIRMED and self.time_from <= now <= (
             self.time_to or now

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -990,6 +990,81 @@ class BookingAutoConfirmPriceCheckTestCase(APITestCase):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["status"] == BookingStatus.CONFIRMED
 
+    def test_rented_out_item_can_still_be_booked_for_future_slot(self):
+        """
+        An item that is currently rented out (active confirmed booking, item
+        status RENTED) can still be booked for a future slot that has no
+        confirmed booking for that time range.
+        """
+        now = timezone.now()
+        active = SelfServiceItemFactory(user=self.item_owner, price=None)
+        self.client.force_authenticate(user=self.booking_user)
+        active_booking = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(active.id),
+                "time_from": now - timedelta(days=1),
+                "time_to": now + timedelta(days=1),
+            },
+            format="json",
+        )
+        assert active_booking.status_code == status.HTTP_201_CREATED, (
+            active_booking.content
+        )
+        assert active_booking.data["status"] == BookingStatus.CONFIRMED
+        active.refresh_from_db()
+        assert active.status == ItemStatus.RENTED
+
+        other_user = UserFactory()
+        other_user.groups.add(self.default_group)
+        self.client.force_authenticate(user=other_user)
+        future = now + timedelta(days=30)
+        response = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(active.id),
+                "time_from": future,
+                "time_to": future + timedelta(days=2),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        assert response.data["status"] == BookingStatus.CONFIRMED
+
+    def test_open_end_self_service_auto_confirms_and_second_is_rejected(self):
+        """
+        On a self-service item that allows open-ended rentals, a booking
+        without a return date is self-approved. The open-end exclusion
+        constraint allows only one confirmed open rental per item, so a second
+        open-ended request gets the friendly overlap error instead of a 500.
+        """
+        open_end_item = SelfServiceItemFactory(
+            user=self.item_owner, price=None, rental_open_end=True
+        )
+        self.client.force_authenticate(user=self.booking_user)
+        first = self.client.post(
+            "/api/bookings/", {"item": str(open_end_item.id)}, format="json"
+        )
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+        assert first.data["status"] == BookingStatus.CONFIRMED
+
+        other_user = UserFactory()
+        other_user.groups.add(self.default_group)
+        self.client.force_authenticate(user=other_user)
+        second = self.client.post(
+            "/api/bookings/", {"item": str(open_end_item.id)}, format="json"
+        )
+        assert second.status_code == status.HTTP_400_BAD_REQUEST, second.content
+        assert "already rented out" in second.data["non_field_errors"][0]
+        # The rejected request must not linger as a confirmed duplicate.
+        assert (
+            Booking.objects.filter(
+                item=open_end_item, status=BookingStatus.CONFIRMED
+            ).count()
+            == 1
+        )
+
 
 class BookingOpenEndRentalTestCase(APITestCase):
     """
@@ -2042,3 +2117,110 @@ class BookingPastCancelValidationTestCase(APITestCase):
         assert response.status_code == status.HTTP_200_OK, response.content
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CANCELLED
+
+
+class BookingTimeFromValidationTestCase(APITestCase):
+    """A booking always needs a start time: without one it cannot be shown on
+    any calendar and its overlap range becomes unbounded below, silently
+    blocking every other booking up to ``time_to``."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.default_group, _ = Group.objects.get_or_create(name=DefaultGroup.DEFAULT)
+
+        self.item_owner = UserFactory()
+        self.item_owner.groups.add(self.default_group)
+
+        self.booking_user = UserFactory()
+        self.booking_user.groups.add(self.default_group)
+
+        self.item = ItemFactory(
+            user=self.item_owner, sales_type=SalesType.RENT, price="10.00"
+        )
+
+    def test_explicit_null_time_from_rejected(self):
+        """Posting ``time_from: null`` is a validation error, not a booking
+        with a mystery start."""
+        self.client.force_authenticate(user=self.booking_user)
+        response = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(self.item.id),
+                "time_from": None,
+                "time_to": timezone.now() + timedelta(days=1),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "time_from" in response.data
+
+    def test_omitted_time_from_defaults_to_now(self):
+        """Omitting ``time_from`` entirely keeps the model default (now)."""
+        self.client.force_authenticate(user=self.booking_user)
+        before = timezone.now()
+        response = self.client.post(
+            "/api/bookings/",
+            {
+                "item": str(self.item.id),
+                "time_to": timezone.now() + timedelta(days=1),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        booking = Booking.objects.get(id=response.data["id"])
+        assert booking.time_from is not None
+        assert before <= booking.time_from <= timezone.now()
+
+    def test_patching_time_from_to_null_rejected(self):
+        """An existing booking cannot be updated to lose its start time."""
+        self.client.force_authenticate(user=self.booking_user)
+        booking = BookingFactory(
+            user=self.booking_user,
+            item=self.item,
+            time_from=timezone.now(),
+            time_to=timezone.now() + timedelta(days=1),
+        )
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"time_from": None},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "time_from" in response.data
+        booking.refresh_from_db()
+        assert booking.time_from is not None
+
+    def test_is_active_false_without_time_from(self):
+        """A booking without a start time is never 'active' (and comparing it
+        to now would raise a TypeError)."""
+        booking = BookingFactory(
+            user=self.booking_user,
+            item=self.item,
+            time_from=None,
+            time_to=timezone.now() + timedelta(days=1),
+        )
+        assert booking.is_active is False
+
+    def test_confirming_legacy_booking_without_time_from_does_not_crash(self):
+        """Regression: confirming a legacy/federated booking whose ``time_from``
+        is NULL used to raise a TypeError in the item-status signal (HTTP 500).
+        It must confirm cleanly instead."""
+        booking = BookingFactory(
+            user=self.booking_user,
+            item=self.item,
+            time_from=None,
+            time_to=timezone.now() + timedelta(days=1),
+        )
+        self.client.force_authenticate(user=self.item_owner)
+        response = self.client.patch(
+            f"/api/bookings/{booking.id}/",
+            {"status": BookingStatus.CONFIRMED},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        booking.refresh_from_db()
+        assert booking.status == BookingStatus.CONFIRMED

--- a/frontend/src/components/items/RentalCalendar.tsx
+++ b/frontend/src/components/items/RentalCalendar.tsx
@@ -158,6 +158,24 @@ export const RentalCalendar = ({
       }));
   }, [bookingsData]);
 
+  // Open-ended rentals (no return date) don't occupy calendar tiles — dated
+  // bookings remain possible — but they must stay visible: only one of them
+  // can be confirmed at a time, and they hold the item until it is returned.
+  const openEndedBookings = useMemo(() => {
+    if (!bookingsData?.results) return [];
+    type BookingWithTime = (typeof bookingsData.results)[0] & {
+      time_from?: string | null;
+      time_to?: string | null;
+    };
+    return (bookingsData.results as BookingWithTime[])
+      .filter(booking => booking.time_from && !booking.time_to)
+      .map(booking => ({
+        start: new Date(booking.time_from!),
+        userId: booking.user.id,
+        userFullName: booking.user.name || booking.user.username,
+      }));
+  }, [bookingsData]);
+
   // All dates use the browser's local timezone
   // JavaScript Date objects automatically work in the user's timezone
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -765,6 +783,42 @@ export const RentalCalendar = ({
           </ActionIcon>
         </div>
       </div>
+
+      {/* Open-ended rentals: no return date, so they never occupy calendar
+          tiles — list them explicitly so they don't stay invisible. */}
+      {openEndedBookings.length > 0 && (
+        <Paper mt="md" p="md" radius="lg" withBorder className="w-full">
+          <div className="flex flex-col gap-2">
+            <Text size="sm" fw={500}>
+              {t('calendar.openEndedRentals')}
+            </Text>
+            {openEndedBookings.map(booking => (
+              <div
+                key={`${booking.userId}-${booking.start.getTime()}`}
+                className="flex items-center gap-2 text-sm"
+              >
+                <span
+                  className={cn(
+                    'inline-block h-2.5 w-2.5 rounded-full shrink-0',
+                    getBookerColor(booking.userId).dot,
+                  )}
+                />
+                <User size={14} className="shrink-0" />
+                <span className="font-medium">{booking.userFullName}</span>
+                <Text size="xs" c="dimmed">
+                  {t('calendar.openEndedSince').replace(
+                    '{date}',
+                    format(booking.start, 'EEE, MMM d, yyyy HH:mm'),
+                  )}
+                </Text>
+              </div>
+            ))}
+            <Text size="xs" c="dimmed">
+              {t('calendar.openEndedNote')}
+            </Text>
+          </div>
+        </Paper>
+      )}
 
       {viewMode === 'weekly' ? renderWeeklyView() : renderMonthlyView()}
 

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -389,6 +389,10 @@ const translations = {
     'calendar.selectedPeriod': 'Selected Period',
     'calendar.from': 'From',
     'calendar.to': 'To',
+    'calendar.openEndedRentals': 'Open-ended rentals',
+    'calendar.openEndedSince': 'since {date}',
+    'calendar.openEndedNote':
+      'These rentals run until the item is returned. Only one open-ended rental can be confirmed at a time.',
     'calendar.duration': 'Duration',
     'calendar.hours': 'hours',
     'calendar.days': 'days',
@@ -1129,6 +1133,10 @@ const translations = {
     'calendar.selectedPeriod': 'Ausgewählter Zeitraum',
     'calendar.from': 'Von',
     'calendar.to': 'Bis',
+    'calendar.openEndedRentals': 'Unbefristete Mieten',
+    'calendar.openEndedSince': 'seit {date}',
+    'calendar.openEndedNote':
+      'Diese Mieten laufen, bis der Artikel zurückgegeben wird. Es kann immer nur eine unbefristete Miete gleichzeitig bestätigt sein.',
     'calendar.duration': 'Dauer',
     'calendar.hours': 'Stunden',
     'calendar.days': 'Tage',


### PR DESCRIPTION
## What

Hardening for the "This item is already rented out or has an open rental" diagnosis: a booking **without a start time** could be created through the API and became an invisible, item-blocking ghost booking.

## Root cause

The frontend sends `time_from: null` when the start field is empty and the serializer accepted it. Such a row:

- turns into an unbounded `tstzrange(NULL, time_to)` in the overlap exclusion constraint, silently blocking **every** booking up to `time_to` with the overlap error,
- is **invisible in the rental calendar** (it filters `time_from && time_to`),
- keeps the item **AVAILABLE** (the periodic task requires `time_from <= now`),
- and crashed the item-status signal with a `TypeError` (HTTP 500) when confirmed — including **federated bookings accepted without `startTime`**.

## Changes

### Backend
- `serializers.py` — `validate_time_from` rejects an explicitly `null` start (omitting the field still falls back to the model default "now").
- `models.py` — `Booking.is_active` returns `False` for a missing `time_from` instead of raising, so confirming such a booking no longer 500s.
- `tests.py` — new tests: null rejected, omitted defaults to now, PATCH-to-null rejected, `is_active` guard, and a regression test that confirming a legacy NULL-start booking returns 200 instead of 500. Plus behavior documentation: an open-ended booking on a self-service item **is self-approved** (maintainer decision — `time_to` restriction reverted), and a second open-ended request gets the friendly overlap error since only one confirmed open rental per item is allowed.

### Frontend
- `RentalCalendar.tsx` — open-ended rentals (no return date) are now listed above the calendar with booker and start date, so the rentals that occupy the item until it is returned are no longer invisible. The slot grid is unchanged: open-ended rentals only conflict with other *open-ended* requests, dated slots remain bookable.
- `LanguageContext.tsx` — new strings (EN + DE).

**Note:** `views.py` is intentionally untouched — auto-approval of open-ended self-service bookings stays in place.

## Verification

- Backend: full suite passes (509 tests), bookings suite 97.
- Frontend: `typecheck` and `eslint` clean.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)