### PR TITLE
feat(calendar): fetch bookings for the visible time range

### DIFF
--- a/backend/bubble/bookings/api/filters.py
+++ b/backend/bubble/bookings/api/filters.py
@@ -1,6 +1,7 @@
 import django_filters
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from guardian.shortcuts import get_objects_for_user
 
 from bubble.bookings.models import Booking, BookingStatus, Message
@@ -35,6 +36,11 @@ class BookingFilter(django_filters.FilterSet):
     time_to_isnull = django_filters.BooleanFilter(
         field_name="time_to", lookup_expr="isnull"
     )
+    # Calendar window: ``visible_from``/``visible_to`` together describe the
+    # time range the calendar currently displays. Both must be provided; they
+    # return every booking that overlaps that range (see filter_visible_window).
+    visible_from = django_filters.IsoDateTimeFilter(method="filter_visible_window")
+    visible_to = django_filters.IsoDateTimeFilter(method="filter_visible_window")
     # role=owner  → only bookings on items the current user owns (has change_item perm)
     # role=renter → only bookings where the current user is the requester
     role = django_filters.CharFilter(
@@ -69,6 +75,28 @@ class BookingFilter(django_filters.FilterSet):
             "role",
             "temporal",
         ]
+
+    def filter_visible_window(self, queryset, name, value):
+        """Only bookings that overlap the calendar's visible time range.
+
+        ``visible_from``/``visible_to`` describe the displayed window as
+        ``[start, end)``. A dated booking overlaps it when it starts before the
+        window ends and ends after the window starts; an open-ended booking
+        (``time_to`` null) overlaps as soon as it started before the window
+        ends. Both parameters must be given, otherwise the filter is a no-op.
+        Bookings without a start time cannot be placed on a calendar and are
+        never returned.
+        """
+        raw_from = self.data.get("visible_from")
+        raw_to = self.data.get("visible_to")
+        window_start = parse_datetime(raw_from) if raw_from else None
+        window_end = parse_datetime(raw_to) if raw_to else None
+        if window_start is None or window_end is None:
+            return queryset
+        return queryset.filter(
+            Q(time_from__lt=window_end)
+            & (Q(time_to__gt=window_start) | Q(time_to__isnull=True))
+        )
 
     def filter_role(self, queryset, name, value):
         request = self.request

--- a/backend/bubble/bookings/api/filters.py
+++ b/backend/bubble/bookings/api/filters.py
@@ -93,6 +93,15 @@ class BookingFilter(django_filters.FilterSet):
         window_end = parse_datetime(raw_to) if raw_to else None
         if window_start is None or window_end is None:
             return queryset
+        # Clients may omit the timezone offset; interpret naive values in the
+        # project timezone instead of letting the database guess.
+        if timezone.is_naive(window_start):
+            window_start = timezone.make_aware(window_start)
+        if timezone.is_naive(window_end):
+            window_end = timezone.make_aware(window_end)
+        if window_start >= window_end:
+            # An empty or inverted window cannot overlap anything.
+            return queryset.none()
         return queryset.filter(
             Q(time_from__lt=window_end)
             & (Q(time_to__gt=window_start) | Q(time_to__isnull=True))

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -2225,6 +2225,7 @@ class BookingTimeFromValidationTestCase(APITestCase):
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CONFIRMED
 
+
 class BookingVisibleWindowFilterTestCase(APITestCase):
     """The rental calendar fetches bookings with ``visible_from``/``visible_to``
     for the time range it displays. A booking must be returned when it overlaps
@@ -2392,3 +2393,41 @@ class BookingVisibleWindowFilterTestCase(APITestCase):
         )
         assert second.status_code == status.HTTP_200_OK, second.content
         assert len(second.data["results"]) == booking_count - page_size
+
+    def test_naive_window_parameters_are_interpreted_locally(self):
+        """Window parameters without a timezone offset must not be silently
+        misinterpreted: they are resolved against the project timezone."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        booking = self._make_booking(
+            booker, self.window_from + timedelta(days=1), self.window_to
+        )
+
+        response = self.client.get(
+            "/api/public-bookings/",
+            {
+                "item": str(self.item.id),
+                "visible_from": self.window_from.replace(tzinfo=None).isoformat(),
+                "visible_to": self.window_to.replace(tzinfo=None).isoformat(),
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = [str(b["id"]) for b in response.data["results"]]
+        assert str(booking.id) in ids
+
+    def test_inverted_window_returns_nothing(self):
+        """A window whose start is not before its end cannot overlap anything."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        self._make_booking(booker, self.window_from + timedelta(days=1), self.window_to)
+
+        response = self.client.get(
+            "/api/public-bookings/",
+            {
+                "item": str(self.item.id),
+                "visible_from": self.window_to.isoformat(),
+                "visible_to": self.window_from.isoformat(),
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.data["results"] == []

--- a/backend/bubble/bookings/tests/tests.py
+++ b/backend/bubble/bookings/tests/tests.py
@@ -141,7 +141,7 @@ class BookingAutoConfirmTestCase(APITestCase):
         response = self.client.get("/api/public-bookings/")
         assert response.status_code == status.HTTP_200_OK
 
-        booking_ids = [b["id"] for b in response.data["results"]]
+        booking_ids = [str(b["id"]) for b in response.data["results"]]
         assert booking_id in booking_ids
 
     def test_pending_booking_not_visible_in_public_endpoint(self):
@@ -165,7 +165,7 @@ class BookingAutoConfirmTestCase(APITestCase):
         response = self.client.get("/api/public-bookings/")
         assert response.status_code == status.HTTP_200_OK
 
-        booking_ids = [b["id"] for b in response.data["results"]]
+        booking_ids = [str(b["id"]) for b in response.data["results"]]
         assert booking_id not in booking_ids
 
     def test_self_service_no_price_item_auto_confirms_without_offer(self):
@@ -2224,3 +2224,171 @@ class BookingTimeFromValidationTestCase(APITestCase):
         assert response.status_code == status.HTTP_200_OK, response.content
         booking.refresh_from_db()
         assert booking.status == BookingStatus.CONFIRMED
+
+class BookingVisibleWindowFilterTestCase(APITestCase):
+    """The rental calendar fetches bookings with ``visible_from``/``visible_to``
+    for the time range it displays. A booking must be returned when it overlaps
+    that range — not when it merely exists for the item."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.default_group, _ = Group.objects.get_or_create(name=DefaultGroup.DEFAULT)
+
+        self.item_owner = UserFactory()
+        self.item_owner.groups.add(self.default_group)
+
+        self.item = ItemFactory(
+            user=self.item_owner, sales_type=SalesType.RENT, price="10.00"
+        )
+        now = timezone.now()
+        # Window: 30 to 40 days out — the range the calendar would display.
+        self.window_from = now + timedelta(days=30)
+        self.window_to = now + timedelta(days=40)
+
+    def _get_visible(self):
+        response = self.client.get(
+            "/api/public-bookings/",
+            {
+                "item": str(self.item.id),
+                "visible_from": self.window_from.isoformat(),
+                "visible_to": self.window_to.isoformat(),
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        return response
+
+    def _make_booking(self, user, time_from, time_to, offer="10.00"):
+        return BookingFactory(
+            user=user,
+            item=self.item,
+            status=BookingStatus.CONFIRMED,
+            time_from=time_from,
+            time_to=time_to,
+            offer=offer,
+        )
+
+    def test_only_overlapping_bookings_are_returned(self):
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        inside = self._make_booking(
+            booker, self.window_from + timedelta(days=1), self.window_to
+        )
+        # Entirely before the window.
+        self._make_booking(
+            booker,
+            self.window_from - timedelta(days=5),
+            self.window_from - timedelta(days=1),
+        )
+        # Entirely after the window.
+        self._make_booking(
+            booker,
+            self.window_to + timedelta(days=1),
+            self.window_to + timedelta(days=5),
+        )
+
+        results = self._get_visible().data["results"]
+        ids = [str(b["id"]) for b in results]
+        assert str(inside.id) in ids
+        assert len(ids) == 1
+
+    def test_partially_overlapping_bookings_are_returned(self):
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        # Started before the window, ends inside it.
+        leading = self._make_booking(
+            booker,
+            self.window_from - timedelta(days=2),
+            self.window_from + timedelta(days=1),
+        )
+        # Starts inside the window, ends after it.
+        trailing = self._make_booking(
+            booker,
+            self.window_to - timedelta(days=1),
+            self.window_to + timedelta(days=2),
+        )
+
+        results = self._get_visible().data["results"]
+        ids = [str(b["id"]) for b in results]
+        assert set(ids) == {str(leading.id), str(trailing.id)}
+
+    def test_open_ended_booking_is_returned(self):
+        """An open-ended booking (time_to null) occupies the item until it is
+        returned, so it overlaps any window that starts after it began."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        open_ended = self._make_booking(
+            booker, self.window_from - timedelta(days=1), None
+        )
+
+        results = self._get_visible().data["results"]
+        ids = [str(b["id"]) for b in results]
+        assert str(open_ended.id) in ids
+
+    def test_boundaries_exclude_touching_bookings(self):
+        """A booking that ends exactly at the window start does not occupy any
+        displayed slot, and one starting exactly at the window end belongs to
+        the next view — neither is returned."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        self._make_booking(
+            booker, self.window_from - timedelta(days=1), self.window_from
+        )
+        self._make_booking(booker, self.window_to, self.window_to + timedelta(days=1))
+
+        results = self._get_visible().data["results"]
+        assert results == []
+
+    def test_missing_window_parameter_is_a_noop(self):
+        """Without both parameters the filter must not silently drop bookings."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        booking = self._make_booking(
+            booker, self.window_from + timedelta(days=1), self.window_to
+        )
+
+        response = self.client.get("/api/public-bookings/", {"item": str(self.item.id)})
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = [str(b["id"]) for b in response.data["results"]]
+        assert str(booking.id) in ids
+
+    def test_pagination_pages_are_browsable(self):
+        """page/page_size work together with the window filter so the calendar
+        can follow next pages."""
+        booker = UserFactory()
+        booker.groups.add(self.default_group)
+        booking_count = 3
+        page_size = 2
+        for offset in range(booking_count):
+            self._make_booking(
+                booker,
+                self.window_from + timedelta(days=offset + 1),
+                self.window_from + timedelta(days=offset + 2),
+            )
+
+        first = self.client.get(
+            "/api/public-bookings/",
+            {
+                "item": str(self.item.id),
+                "visible_from": self.window_from.isoformat(),
+                "visible_to": self.window_to.isoformat(),
+                "page": 1,
+                "page_size": page_size,
+            },
+        )
+        assert first.status_code == status.HTTP_200_OK, first.content
+        assert first.data["count"] == booking_count
+        assert len(first.data["results"]) == page_size
+        assert first.data["next"] is not None
+
+        second = self.client.get(
+            "/api/public-bookings/",
+            {
+                "item": str(self.item.id),
+                "visible_from": self.window_from.isoformat(),
+                "visible_to": self.window_to.isoformat(),
+                "page": 2,
+                "page_size": page_size,
+            },
+        )
+        assert second.status_code == status.HTTP_200_OK, second.content
+        assert len(second.data["results"]) == booking_count - page_size

--- a/frontend/src/components/items/RentalCalendar.tsx
+++ b/frontend/src/components/items/RentalCalendar.tsx
@@ -44,6 +44,75 @@ const NOON_HOUR = 12;
 const CALENDAR_PAGE_SIZE = 100;
 const CALENDAR_MAX_PAGES = 20;
 
+// Module-level helpers for the monthly-view default start. They are pure so
+// they can be used inside memoized values without breaking memoization.
+
+/** True when any booking overlaps the half-open range [rangeStart, rangeEnd). */
+const anyBookingOverlaps = (
+  bookings: { start: Date; end: Date }[],
+  rangeStart: Date,
+  rangeEnd: Date,
+): boolean => bookings.some(booking => rangeStart < booking.end && booking.start < rangeEnd);
+
+/** True when the hour slot [day+hour, day+hour+1) is free and not in the past. */
+const hourSlotIsBookable = (
+  bookings: { start: Date; end: Date }[],
+  day: Date,
+  hour: number,
+): boolean => {
+  const slotStart = new Date(day);
+  slotStart.setHours(hour, 0, 0, 0);
+  if (isBefore(slotStart, new Date())) return false;
+  const slotEnd = new Date(slotStart);
+  slotEnd.setHours(hour + 1, 0, 0, 0);
+  return !anyBookingOverlaps(bookings, slotStart, slotEnd);
+};
+
+/** A day is partially booked when part of it is taken but bookable time remains. */
+const dayIsPartiallyBooked = (
+  bookings: { start: Date; end: Date }[],
+  day: Date,
+  isDaily: boolean,
+): boolean => {
+  const dayStart = startOfDay(day);
+  if (isDaily) {
+    const noon = addHours(dayStart, NOON_HOUR);
+    const morningBooked = anyBookingOverlaps(bookings, dayStart, noon);
+    const afternoonBooked = anyBookingOverlaps(bookings, noon, addDays(dayStart, 1));
+    return morningBooked !== afternoonBooked;
+  }
+  if (!anyBookingOverlaps(bookings, dayStart, addHours(dayStart, 24))) return false;
+  for (let hour = 0; hour < 24; hour += 1) {
+    if (hourSlotIsBookable(bookings, day, hour)) return true;
+  }
+  return false;
+};
+
+/**
+ * The datetime a monthly-view selection starts at: noon-based for daily
+ * rentals, midnight for hour-based ones — shifted to the first free hour of
+ * the day when that day is already partially booked. The first free hour is
+ * never earlier than the noon turnover (12:00); earlier hours are only used
+ * when the whole afternoon is taken.
+ */
+const monthStartFor = (
+  bookings: { start: Date; end: Date }[],
+  day: Date,
+  isDaily: boolean,
+): Date => {
+  const dayStart = startOfDay(day);
+  if (!dayIsPartiallyBooked(bookings, day, isDaily)) {
+    return addHours(dayStart, isDaily ? NOON_HOUR : 0);
+  }
+  for (let hour = NOON_HOUR; hour < 24; hour += 1) {
+    if (hourSlotIsBookable(bookings, day, hour)) return addHours(dayStart, hour);
+  }
+  for (let hour = 0; hour < NOON_HOUR; hour += 1) {
+    if (hourSlotIsBookable(bookings, day, hour)) return addHours(dayStart, hour);
+  }
+  return addHours(dayStart, isDaily ? NOON_HOUR : 0);
+};
+
 // Fixed palette (not the "selected" green or a semantic red) so each
 // booker gets a consistent, distinguishable color. Class names are kept
 // literal so Tailwind's static scanner can pick them up.
@@ -196,15 +265,24 @@ export const RentalCalendar = ({
       time_from?: string | null;
       time_to?: string | null;
     };
+    const now = new Date();
     return (bookingsData.results as BookingWithTime[])
-      .filter(booking => booking.time_from && booking.time_to)
-      .map(booking => ({
-        start: new Date(booking.time_from!),
-        end: new Date(booking.time_to!),
-        userId: booking.user.id,
-        userName: booking.user.username,
-        userFullName: booking.user.name || booking.user.username,
-      }));
+      .filter(booking => booking.time_from)
+      .map(booking => {
+        // An open-ended rental (no return date) occupies the item until it
+        // is returned, so it is drawn up to "now"; later slots stay bookable
+        // with a return date. A rental that has not started yet draws
+        // nothing (its range is inverted until it begins).
+        const openEnded = !booking.time_to;
+        return {
+          start: new Date(booking.time_from!),
+          end: openEnded ? now : new Date(booking.time_to!),
+          openEnded,
+          userId: booking.user.id,
+          userName: booking.user.username,
+          userFullName: booking.user.name || booking.user.username,
+        };
+      });
   }, [bookingsData]);
 
   // Open-ended rentals (no return date) don't occupy calendar tiles — dated
@@ -272,16 +350,18 @@ export const RentalCalendar = ({
       let rangeStart: Date;
       let rangeEnd: Date;
       if (isDailyRental) {
-        // Check in at noon on the start day; check out at noon on the end
-        // day itself (that day's morning is still the departing guest's, so
-        // its afternoon is free for someone else). The same tile clicked
-        // twice means a single night, so the checkout rolls to the next day.
-        rangeStart = addHours(start, NOON_HOUR);
+        // Check in at the start day's default hour (noon on a free day; the
+        // first free hour on a partially booked day) and check out at noon
+        // on the end day itself (that day's morning is still the departing
+        // guest's, so its afternoon is free for someone else). The same tile
+        // clicked twice means a single night, so the checkout rolls to the
+        // next day.
+        rangeStart = monthStartFor(existingBookings, start, isDailyRental);
         rangeEnd = isSameDay(start, end)
           ? addHours(addDays(end, 1), NOON_HOUR)
           : addHours(end, NOON_HOUR);
       } else {
-        rangeStart = start;
+        rangeStart = monthStartFor(existingBookings, start, isDailyRental);
         rangeEnd = addDays(end, 1); // Next day at 00:00:00 for full 24h
       }
 
@@ -511,7 +591,8 @@ export const RentalCalendar = ({
 
   // Live range while a start is pending: ordered start/end plus the unit padding
   // (a full hour in weekly view, a full day — or noon-to-noon for daily
-  // rentals — in monthly) used for the final booking.
+  // rentals — in monthly) used for the final booking. The start day uses its
+  // default check-in hour (first free hour on a partially booked day).
   const previewRange = useMemo(() => {
     if (!selectingStart || !hoveredDate) return null;
     const [start, last] = isBefore(hoveredDate, selectingStart)
@@ -522,14 +603,15 @@ export const RentalCalendar = ({
       return { start, end: new Date(last.getTime() + 60 * 60 * 1000) };
     }
     if (isDailyRental) {
-      const rangeStart = addHours(start, NOON_HOUR);
-      const rangeEnd = isSameDay(start, last)
-        ? addHours(addDays(last, 1), NOON_HOUR)
-        : addHours(last, NOON_HOUR);
-      return { start: rangeStart, end: rangeEnd };
+      return {
+        start: monthStartFor(existingBookings, start, isDailyRental),
+        end: isSameDay(start, last)
+          ? addHours(addDays(last, 1), NOON_HOUR)
+          : addHours(last, NOON_HOUR),
+      };
     }
-    return { start, end: addDays(last, 1) };
-  }, [selectingStart, hoveredDate, viewMode, isDailyRental]);
+    return { start: monthStartFor(existingBookings, start, isDailyRental), end: addDays(last, 1) };
+  }, [selectingStart, hoveredDate, viewMode, isDailyRental, existingBookings]);
 
   const renderWeeklyView = () => (
     <div className="overflow-x-auto" onMouseLeave={() => selectingStart && setHoveredDate(null)}>
@@ -584,9 +666,11 @@ export const RentalCalendar = ({
                     disabled={isPast && !isBooked}
                     className={cn(
                       'h-8 rounded transition-colors w-full',
-                      isPast && 'bg-[var(--mantine-color-gray-2)] cursor-not-allowed opacity-50',
-                      isBooked && !isPast && bookerColor && [bookerColor.bg, bookerColor.border],
-                      isBooked && !isPast && 'cursor-pointer opacity-70 border',
+                      isPast &&
+                        !isBooked &&
+                        'bg-[var(--mantine-color-gray-2)] cursor-not-allowed opacity-50',
+                      isBooked && bookerColor && [bookerColor.bg, bookerColor.border],
+                      isBooked && 'cursor-pointer opacity-70 border',
                       !isClickDisabled &&
                         !isHighlighted &&
                         !isPreview &&
@@ -617,7 +701,9 @@ export const RentalCalendar = ({
                           </div>
                           <Text size="xs" c="dimmed">
                             {format(booking.start, 'MMM d, HH:mm')} -{' '}
-                            {format(booking.end, 'MMM d, HH:mm')}
+                            {booking.openEnded
+                              ? t('calendar.untilReturned')
+                              : format(booking.end, 'MMM d, HH:mm')}
                           </Text>
                         </div>
                       </Popover.Dropdown>
@@ -673,10 +759,8 @@ export const RentalCalendar = ({
             const halfBookerColor = halfBooking ? getBookerColor(halfBooking.userId) : null;
             return cn(
               'flex-1 w-full',
-              isPast && 'bg-[var(--mantine-color-gray-2)]',
-              !isPast &&
-                halfBooked &&
-                halfBookerColor && [halfBookerColor.bg, halfBookerColor.border],
+              isPast && !halfBooked && 'bg-[var(--mantine-color-gray-2)]',
+              halfBooked && halfBookerColor && [halfBookerColor.bg, halfBookerColor.border],
               !isPast && halfBooked && half === 'morning' && 'border-b',
               !isPast && halfBooked && half === 'afternoon' && 'border-t',
               !isPast && !halfBooked && isHighlighted && 'bg-[var(--mantine-color-green-6)]',
@@ -727,14 +811,15 @@ export const RentalCalendar = ({
               className={cn(
                 'h-16 rounded transition-colors flex flex-col items-center justify-center p-1 w-full',
                 !isCurrentMonth && 'text-[var(--mantine-color-dimmed)]',
-                isPast && 'bg-[var(--mantine-color-gray-2)] cursor-not-allowed opacity-50',
+                isPast &&
+                  !isBooked &&
+                  'bg-[var(--mantine-color-gray-2)] cursor-not-allowed opacity-50',
                 isBooked &&
-                  !isPast &&
                   bookings[0] && [
                     getBookerColor(bookings[0].userId).bg,
                     getBookerColor(bookings[0].userId).border,
                   ],
-                isBooked && !isPast && 'cursor-pointer opacity-70 border',
+                isBooked && 'cursor-pointer opacity-70 border',
                 !isClickDisabled &&
                   !isHighlighted &&
                   !isPreview &&
@@ -772,7 +857,10 @@ export const RentalCalendar = ({
                           <span className="font-medium">{booking.userFullName}</span>
                         </div>
                         <Text size="xs" c="dimmed" className="ml-5">
-                          {format(booking.start, 'HH:mm')} - {format(booking.end, 'HH:mm')}
+                          {format(booking.start, 'HH:mm')} -{' '}
+                          {booking.openEnded
+                            ? t('calendar.untilReturned')
+                            : format(booking.end, 'HH:mm')}
                         </Text>
                       </div>
                     ))}

--- a/frontend/src/components/items/RentalCalendar.tsx
+++ b/frontend/src/components/items/RentalCalendar.tsx
@@ -19,6 +19,7 @@ import {
   addMonths,
   addWeeks,
   eachDayOfInterval,
+  endOfDay,
   endOfMonth,
   endOfWeek,
   format,
@@ -37,6 +38,11 @@ import { useMemo, useState } from 'react';
 // day, so the same calendar day can host a morning checkout and an
 // afternoon check-in without the two bookings overlapping.
 const NOON_HOUR = 12;
+
+// Bookings are fetched page by page (page_size caps at 100 server-side);
+// CALENDAR_MAX_PAGES bounds the follow-next loop as a safety net.
+const CALENDAR_PAGE_SIZE = 100;
+const CALENDAR_MAX_PAGES = 20;
 
 // Fixed palette (not the "selected" green or a semantic red) so each
 // booker gets a consistent, distinguishable color. Class names are kept
@@ -124,18 +130,61 @@ export const RentalCalendar = ({
     isDailyRental ? 'monthly' : 'weekly',
   );
 
-  // Fetch existing bookings for this item
+  // All dates use the browser's local timezone
+  // JavaScript Date objects automatically work in the user's timezone
+  const [currentDate, setCurrentDate] = useState(new Date());
+  // First click of a range selection (a datetime in weekly view, a day in monthly).
+  const [selectingStart, setSelectingStart] = useState<Date | null>(null);
+  // Tile currently under the pointer while a start is pending — drives the live preview.
+  const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
+
+  // Time range the calendar currently displays — the monthly grid shows the
+  // leading/trailing days of the adjacent weeks, so the window follows the
+  // rendered grid, not just the month.
+  const visibleWindow = useMemo(() => {
+    if (viewMode === 'weekly') {
+      return {
+        start: startOfDay(currentDate),
+        end: endOfDay(addDays(currentDate, 6)),
+      };
+    }
+    return {
+      start: startOfWeek(startOfMonth(currentDate), { weekStartsOn: 1 }),
+      end: endOfWeek(endOfMonth(currentDate), { weekStartsOn: 1 }),
+    };
+  }, [currentDate, viewMode]);
+
+  // Fetch the bookings for the displayed time range. The window is part of
+  // the query key, so navigating to another week/month re-fetches the
+  // entries that belong to that range.
   const { data: bookingsData } = useQuery({
-    queryKey: ['publicBookings', itemUuid],
+    queryKey: [
+      'publicBookings',
+      itemUuid,
+      visibleWindow.start.toISOString(),
+      visibleWindow.end.toISOString(),
+    ],
     queryFn: async () => {
       if (!itemUuid) return null;
-      const response = await publicBookingsList({
-        query: {
-          item: itemUuid,
-          status: [1, 3], // Pending (1) and Confirmed (3) bookings
-        },
-      });
-      return response.data;
+      const baseQuery = {
+        item: itemUuid,
+        status: [1, 3] as [1, 3], // Pending (1) and Confirmed (3) bookings
+        page_size: CALENDAR_PAGE_SIZE,
+        visible_from: visibleWindow.start.toISOString(),
+        visible_to: visibleWindow.end.toISOString(),
+      };
+      const first = await publicBookingsList({ query: { ...baseQuery, page: 1 } });
+      const results = [...(first.data?.results ?? [])];
+      // Follow next pages so a busy time range is never shown partially.
+      let next = first.data?.next;
+      let page = 1;
+      while (next && page < CALENDAR_MAX_PAGES) {
+        page += 1;
+        const response = await publicBookingsList({ query: { ...baseQuery, page } });
+        results.push(...(response.data?.results ?? []));
+        next = response.data?.next;
+      }
+      return { results };
     },
     enabled: !!itemUuid,
   });
@@ -175,14 +224,6 @@ export const RentalCalendar = ({
         userFullName: booking.user.name || booking.user.username,
       }));
   }, [bookingsData]);
-
-  // All dates use the browser's local timezone
-  // JavaScript Date objects automatically work in the user's timezone
-  const [currentDate, setCurrentDate] = useState(new Date());
-  // First click of a range selection (a datetime in weekly view, a day in monthly).
-  const [selectingStart, setSelectingStart] = useState<Date | null>(null);
-  // Tile currently under the pointer while a start is pending — drives the live preview.
-  const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
 
   const currentWeekStart = useMemo(() => startOfDay(currentDate), [currentDate]);
 

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -396,6 +396,7 @@ const translations = {
     'calendar.duration': 'Duration',
     'calendar.hours': 'hours',
     'calendar.days': 'days',
+    'calendar.untilReturned': 'until returned',
     'calendar.selectingPeriod': 'Selecting period',
     'calendar.clickToSetEnd': 'Click an end tile to confirm, or hover to preview',
     'calendar.clearSelection': 'Clear',
@@ -1140,6 +1141,7 @@ const translations = {
     'calendar.duration': 'Dauer',
     'calendar.hours': 'Stunden',
     'calendar.days': 'Tage',
+    'calendar.untilReturned': 'bis zurückgegeben',
     'calendar.selectingPeriod': 'Zeitraum wählen',
     'calendar.clickToSetEnd':
       'Klicke ein End-Feld zum Bestätigen oder bewege die Maus für eine Vorschau',

--- a/frontend/src/services/django/sdk.gen.ts
+++ b/frontend/src/services/django/sdk.gen.ts
@@ -1037,7 +1037,10 @@ export const configRetrieve = <ThrowOnError extends boolean = true>(options?: Op
  * Query parameters
  * ----------------
  * search : str
- * Case-insensitive substring match on name / description.
+ * Case-insensitive match on name / description. Every term has to occur,
+ * accents are folded, misspelled terms still match similar titles, and
+ * results come back ranked with title matches first — the same rules the
+ * local item list uses, applied to local and remote items alike.
  * scope : ``local`` | ``federated`` | ``all`` (default ``all``)
  * Restrict results to local items, remote items, or both.
  * category : str

--- a/frontend/src/services/django/types.gen.ts
+++ b/frontend/src/services/django/types.gen.ts
@@ -938,8 +938,15 @@ export type Message = {
 /**
  * Flat serializer for GET/PATCH /api/notification-preferences/me/.
  *
- * For every provider (RocketChat, Signal, Email) it exposes:
+ * For every provider (webpush, RocketChat, Signal, Matrix, email) it
+ * exposes:
  *
+ * * ``<provider>_configured`` (read-only): the channel is set up on the
+ * backend, independent of whether this particular user is reachable on
+ * it yet. For the Apprise-backed channels (RocketChat, Signal, Matrix,
+ * email) that means an Apprise URL template is configured (Constance/env);
+ * for ``webpush`` it means a VAPID keypair is configured. The frontend
+ * uses this to decide whether to prefill a user's address for a channel.
  * * ``<provider>_available`` (read-only): the channel is configured on the
  * backend *and* the user has filled in the field it needs to reach them.
  * For ``webpush`` there is no such field — availability means at least one
@@ -949,6 +956,13 @@ export type Message = {
  * * ``<provider>_<group>`` (read/write): per event-group opt-in toggles.
  * ``messages`` covers new messages and bookings; ``new_item`` covers newly
  * created items.
+ *
+ * Additionally exposes ``matrix_default_id`` (read-only): the Matrix ID the
+ * frontend should prefill for this user (their bubble username on this
+ * deployment's own homeserver — see ``APPRISE_MATRIX_HOSTNAME``), or "" when
+ * that can't be determined. Every other channel's target is derived
+ * automatically (bubble username/email), so only Matrix needs a suggested
+ * default for the user to accept or edit.
  */
 export type NotificationPreferenceMe = {
     readonly matrix_default_id: string;
@@ -1494,8 +1508,15 @@ export type PatchedMessage = {
 /**
  * Flat serializer for GET/PATCH /api/notification-preferences/me/.
  *
- * For every provider (RocketChat, Signal, Email) it exposes:
+ * For every provider (webpush, RocketChat, Signal, Matrix, email) it
+ * exposes:
  *
+ * * ``<provider>_configured`` (read-only): the channel is set up on the
+ * backend, independent of whether this particular user is reachable on
+ * it yet. For the Apprise-backed channels (RocketChat, Signal, Matrix,
+ * email) that means an Apprise URL template is configured (Constance/env);
+ * for ``webpush`` it means a VAPID keypair is configured. The frontend
+ * uses this to decide whether to prefill a user's address for a channel.
  * * ``<provider>_available`` (read-only): the channel is configured on the
  * backend *and* the user has filled in the field it needs to reach them.
  * For ``webpush`` there is no such field — availability means at least one
@@ -1505,6 +1526,13 @@ export type PatchedMessage = {
  * * ``<provider>_<group>`` (read/write): per event-group opt-in toggles.
  * ``messages`` covers new messages and bookings; ``new_item`` covers newly
  * created items.
+ *
+ * Additionally exposes ``matrix_default_id`` (read-only): the Matrix ID the
+ * frontend should prefill for this user (their bubble username on this
+ * deployment's own homeserver — see ``APPRISE_MATRIX_HOSTNAME``), or "" when
+ * that can't be determined. Every other channel's target is derived
+ * automatically (bubble username/email), so only Matrix needs a suggested
+ * default for the user to accept or edit.
  */
 export type PatchedNotificationPreferenceMe = {
     readonly matrix_default_id?: string;
@@ -2662,8 +2690,15 @@ export type MessageWritable = {
 /**
  * Flat serializer for GET/PATCH /api/notification-preferences/me/.
  *
- * For every provider (RocketChat, Signal, Email) it exposes:
+ * For every provider (webpush, RocketChat, Signal, Matrix, email) it
+ * exposes:
  *
+ * * ``<provider>_configured`` (read-only): the channel is set up on the
+ * backend, independent of whether this particular user is reachable on
+ * it yet. For the Apprise-backed channels (RocketChat, Signal, Matrix,
+ * email) that means an Apprise URL template is configured (Constance/env);
+ * for ``webpush`` it means a VAPID keypair is configured. The frontend
+ * uses this to decide whether to prefill a user's address for a channel.
  * * ``<provider>_available`` (read-only): the channel is configured on the
  * backend *and* the user has filled in the field it needs to reach them.
  * For ``webpush`` there is no such field — availability means at least one
@@ -2673,6 +2708,13 @@ export type MessageWritable = {
  * * ``<provider>_<group>`` (read/write): per event-group opt-in toggles.
  * ``messages`` covers new messages and bookings; ``new_item`` covers newly
  * created items.
+ *
+ * Additionally exposes ``matrix_default_id`` (read-only): the Matrix ID the
+ * frontend should prefill for this user (their bubble username on this
+ * deployment's own homeserver — see ``APPRISE_MATRIX_HOSTNAME``), or "" when
+ * that can't be determined. Every other channel's target is derived
+ * automatically (bubble username/email), so only Matrix needs a suggested
+ * default for the user to accept or edit.
  */
 export type NotificationPreferenceMeWritable = {
     webpush_messages?: boolean;
@@ -3082,8 +3124,15 @@ export type PatchedMessageWritable = {
 /**
  * Flat serializer for GET/PATCH /api/notification-preferences/me/.
  *
- * For every provider (RocketChat, Signal, Email) it exposes:
+ * For every provider (webpush, RocketChat, Signal, Matrix, email) it
+ * exposes:
  *
+ * * ``<provider>_configured`` (read-only): the channel is set up on the
+ * backend, independent of whether this particular user is reachable on
+ * it yet. For the Apprise-backed channels (RocketChat, Signal, Matrix,
+ * email) that means an Apprise URL template is configured (Constance/env);
+ * for ``webpush`` it means a VAPID keypair is configured. The frontend
+ * uses this to decide whether to prefill a user's address for a channel.
  * * ``<provider>_available`` (read-only): the channel is configured on the
  * backend *and* the user has filled in the field it needs to reach them.
  * For ``webpush`` there is no such field — availability means at least one
@@ -3093,6 +3142,13 @@ export type PatchedMessageWritable = {
  * * ``<provider>_<group>`` (read/write): per event-group opt-in toggles.
  * ``messages`` covers new messages and bookings; ``new_item`` covers newly
  * created items.
+ *
+ * Additionally exposes ``matrix_default_id`` (read-only): the Matrix ID the
+ * frontend should prefill for this user (their bubble username on this
+ * deployment's own homeserver — see ``APPRISE_MATRIX_HOSTNAME``), or "" when
+ * that can't be determined. Every other channel's target is derived
+ * automatically (bubble username/email), so only Matrix needs a suggested
+ * default for the user to accept or edit.
  */
 export type PatchedNotificationPreferenceMeWritable = {
     webpush_messages?: boolean;
@@ -3360,7 +3416,7 @@ export type BooksListData = {
         page?: number;
         publisher_name?: string;
         /**
-         * Ein Suchbegriff.
+         * Free-text search over title, description, author, publisher, topic and ISBN. All terms must match; use "quotes" to search for a phrase. Accents are ignored and misspelled terms still match similar titles. Results are ranked with title matches first and approximate matches last.
          */
         search?: string;
         shelf_name?: string;
@@ -4281,7 +4337,7 @@ export type ItemsListData = {
          */
         sales_type?: Array<'borrow' | 'donate' | 'rent' | 'sell' | 'want_buy' | 'want_rent'>;
         /**
-         * Ein Suchbegriff.
+         * Free-text search over title and description. All terms must match; use "quotes" to search for a phrase. Accents are ignored and misspelled terms still match similar titles. Results are ranked with title matches first and approximate matches last.
          */
         search?: string;
         /**
@@ -4940,6 +4996,8 @@ export type PublicBookingsListData = {
         time_to_before?: string;
         time_to_isnull?: boolean;
         user?: string;
+        visible_from?: string;
+        visible_to?: string;
     };
     url: '/api/public-bookings/';
 };
@@ -5024,7 +5082,7 @@ export type PublicItemsListData = {
          */
         sales_type?: Array<'borrow' | 'donate' | 'rent' | 'sell' | 'want_buy' | 'want_rent'>;
         /**
-         * Ein Suchbegriff.
+         * Free-text search over title and description. All terms must match; use "quotes" to search for a phrase. Accents are ignored and misspelled terms still match similar titles. Results are ranked with title matches first and approximate matches last.
          */
         search?: string;
         /**


### PR DESCRIPTION
## What

The rental calendar fetched only the **first page** of *all* bookings for an item, unscoped by time. On busy items, booked slots were silently missing from the grid, past dates showed nothing, and navigating weeks/months never re-fetched the right entries.

Example (before): `/api/public-bookings/?item=…&status=1&status=3` — returns page 1 (20 items) of *every* booking the item ever had.

## Changes

### Backend — `bubble/bookings/api/filters.py`
New `visible_from` / `visible_to` filters on `BookingFilter` (both required together, otherwise no-op). They return every booking that **overlaps** the displayed window `[visible_from, visible_to)`:
- dated bookings: `time_from < visible_to AND time_to > visible_from` — strict comparisons match the rendered slot grid exactly (a booking ending at the window start doesn't occupy a displayed slot; one ending at the window end does),
- open-ended bookings (`time_to` null) overlap as long as they started before the window ends,
- bookings without a `time_from` can never be placed on a calendar and are never returned,
- naive window parameters (no timezone offset) are resolved against the project timezone; an empty or inverted window returns no results.

### Frontend — `RentalCalendar.tsx`
- Computes the visible window from the **rendered grid** (weekly: the shown 7 days; monthly: grid including leading/trailing adjacent-week days) and passes `visible_from`/`visible_to` to the API.
- The window is part of the React Query key → navigating to another week/month automatically re-fetches the correct entries.
- Follows `next` pages (`page_size=100`, bounded loop) so a busy time range is never shown partially.
- **Past dates now show who booked them** — booker colors and the name popover work on past tiles too — while past slots remain unbookable as before.
- **Open-ended rentals are drawn on the calendar** up to "now" (the days they occupy until the item is returned are visible; the popover says "until returned"), and later slots stay bookable with a return date.
- **Clicking a partially booked day in the monthly view** defaults the start to the first free hour of that day, never earlier than the noon turnover (12:00); free days keep their previous defaults (noon for daily rentals, midnight for hourly ones).

### SDK
Regenerated from the updated OpenAPI schema (adds `visible_from`/`visible_to`/`page`/`page_size`).

## Verification

- 8 new backend tests (`BookingVisibleWindowFilterTestCase`): inside-only, partial overlaps on both edges, open-ended inclusion, boundary exclusions, missing-param no-op, naive timezones, inverted window, and pagination browsing.
- Backend suite: 508 passed; `ruff` clean.
- Frontend `typecheck` / `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)